### PR TITLE
Fixed a few typos in the documentation

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -57,7 +57,7 @@ cmdstanr::install_cmdstan()
 
 ## Quick start
 
-In this quick start we use COVID-19 hospitalisations by date of positive test in Germany available up to the 1st of October 2021 to demonstrate the specification and fitting of a simple nowcasting model using `epinowcast`.Examples using more complex models are available in the package vignettes and in the papers linked to in the literature vignette.
+In this quick start we use COVID-19 hospitalisations by date of positive test in Germany available up to the 1st of October 2021 to demonstrate the specification and fitting of a simple nowcasting model using `epinowcast`. Examples using more complex models are available in the package vignettes and in the papers linked to in the literature vignette.
 
 ### Package
 
@@ -162,7 +162,7 @@ plot(nowcast, type = "posterior") +
 
 ## Citation
 
-If using `epinowccast` in your work please consider citing it using the following,
+If using `epinowcast` in your work please consider citing it using the following,
 
 ```{r, echo = FALSE}
 citation("epinowcast")

--- a/vignettes/germany-age-stratified-nowcasting.Rmd
+++ b/vignettes/germany-age-stratified-nowcasting.Rmd
@@ -79,7 +79,7 @@ latest_nat_germany <- enw_latest_data(latest_nat_germany)
 
 # Data preprocessing
 
-`epinowcast` works by assuming data has been preprocessed into the format it expects. It is at this stage that arbitrary groupings of observations can be defined which will then be propagated throughout all subsequent modelling steps. Here we have data stratified by age and so group by age group but in principle this could be any grouping or combination of groups independent of the reference and report date models. Here we also assume a maximum delay required to make the model identifiable. We set this to 40 days due to evidence of long reporting delays in this example data but note that in most cases the majority of right censoring occurs in the first few days and that increasing the maximum delay has a non-linear effect on run-time (i.e a 20 day delay will be much faster to fit a model for than a 40 day delay). Note also that under the current formulation delays longer than the maximum are ignored so that the adjusted estimate is really for data reported after the maximum delay rather than for finally reported data.
+`epinowcast` works by assuming data has been preprocessed into the format it expects. It is at this stage that arbitrary groupings of observations can be defined which will then be propagated throughout all subsequent modelling steps. Here we have data stratified by age and so grouped by age group but in principle this could be any grouping or combination of groups independent of the reference and report date models. Here we also assume a maximum delay required to make the model identifiable. We set this to 40 days due to evidence of long reporting delays in this example data but note that in most cases the majority of right censoring occurs in the first few days and that increasing the maximum delay has a non-linear effect on run-time (i.e a 20 day delay will be much faster to fit a model for than a 40 day delay). Note also that under the current formulation delays longer than the maximum are ignored so that the adjusted estimate is really for data reported after the maximum delay rather than for finally reported data.
 
 Another key modelling choice we make at this stage is to model age groups jointly with aggregated hospitalisations. This implicitly assumes that aggregated and non-aggregated data are not comparable (which may or may not be the case) but that the reporting process shares some of the same mechanisms. Another way to approach this would be to only model age stratified hospitalisations and then to aggregate the nowcast estimates into total counts after fitting the model which assumes that this aggregation is possible.
 
@@ -664,7 +664,7 @@ kable(overall_score)
 |Reference: Age group, Report: Day of week          |           14.2|      2.83|           10.40|          0.921|            -0.0900| -0.214| 21.9|
 |Reference: Age group and week, Report: Day of week |           14.0|      2.93|            9.94|          1.150|            -0.0978| -0.174| 21.6|
 
-Stratifying by age group we see that trends in performance are fairly consistent with some small variation in the ordering of which model out performs the others. 
+Stratifying by age group we see that trends in performance are fairly consistent with some small variation in the ordering of which model outperforms the others. 
 
 
 ```r

--- a/vignettes/model.Rmd
+++ b/vignettes/model.Rmd
@@ -18,7 +18,7 @@ knitr::opts_chunk$set(
 )
 ```
 
-In the following sections we provide methodological and implementation details for the nowcasting framework implemented in `epinowcast`. Our approach is an extension of that proposed by Günther et al.[@gunther2021] which was itself an extension of the model proposed by Höhle and Heiden[@hohle] and implemented in the `surveillance` R package[@surveillance]. Compared to the model proposed in Günther et al.[@gunther2021], `epinowcast` adds an optional parametric assumption for the underlying delay from occurrence to report, support for jointly nowcasting multiple related datasets, a flexible formula interface allowing for the specification of a large range of models, and an efficient implementation in `stan` which makes use of sparse design matrices and within chain parallisation to reduce runtimes [@stan; @cmdstanr].
+In the following sections we provide methodological and implementation details for the nowcasting framework implemented in `epinowcast`. Our approach is an extension of that proposed by Günther et al.[@gunther2021] which was itself an extension of the model proposed by Höhle and Heiden[@hohle] and implemented in the `surveillance` R package[@surveillance]. Compared to the model proposed in Günther et al.[@gunther2021], `epinowcast` adds an optional parametric assumption for the underlying delay from occurrence to report, support for jointly nowcasting multiple related datasets, a flexible formula interface allowing for the specification of a large range of models, and an efficient implementation in `stan` which makes use of sparse design matrices and within chain parallelisation to reduce runtimes [@stan; @cmdstanr].
 
 # Decomposition into expected final notifications and report delay components
 
@@ -34,7 +34,7 @@ An alternative approach, not explored here, is to consider each $n_{gtd}$ indepe
 
 # Expected final notifications
 
-Here we follow the approach of Günther et al.[gunther2021] and specify the model for expected final notifications as a first order random walk. This model can in principle be any model such as a more complex time-series approach, a gaussian process, or a mechanistic or semi-mechanistic compartmental model. Extending the flexibility of this model is an area of further work as is evaluating the benefits and tradeoffs of more complex approaches.
+Here we follow the approach of Günther et al.[@gunther2021] and specify the model for expected final notifications as a first order random walk. This model can in principle be any model such as a more complex time-series approach, a gaussian process, or a mechanistic or semi-mechanistic compartmental model. Extending the flexibility of this model is an area of further work as is evaluating the benefits and tradeoffs of more complex approaches.
 
 \begin{align}
   \log (\lambda_{gt}) &\sim \text{Normal}\left(\log (\lambda_{gt-1}) , \sigma^{\lambda}_{g} \right) \\
@@ -92,6 +92,6 @@ Expected notifications by time of occurrence ($t$) and reporting delay can now b
 
 # Implementation
 
-The model is implemented in `stan` using `cmdstanr` with no defaults altered[@stan; @cmdstanr]. Optional within chain parallisation is available across dates of occurrence to reduce runtimes. Sparse design matrices have been used for all covariates to limit the number of probability mass functions that need to be calculated. `epinowcast` incorporates additional functionality written in R[@R] to enable plotting nowcasts and posterior predictions, summarising nowcasts, and scoring them using `scoringutils`[@scoringutils]. All functionality is modular allowing users to extend and alter the underlying model whilst continuing to use the package framework.
+The model is implemented in `stan` using `cmdstanr` with no defaults altered[@stan; @cmdstanr]. Optional within chain parallelisation is available across dates of occurrence to reduce runtimes. Sparse design matrices have been used for all covariates to limit the number of probability mass functions that need to be calculated. `epinowcast` incorporates additional functionality written in R[@R] to enable plotting nowcasts and posterior predictions, summarising nowcasts, and scoring them using `scoringutils`[@scoringutils]. All functionality is modular allowing users to extend and alter the underlying model whilst continuing to use the package framework.
 
 # References


### PR DESCRIPTION
I've just fixed a few typos in the documentation (README and vignettes). 

Thank you very much for the development of this very useful package! 