### PR TITLE
Bug: drop na.rm requirement for posterior functions

### DIFF
--- a/R/postprocess.R
+++ b/R/postprocess.R
@@ -42,8 +42,7 @@ enw_posterior <- function(fit, variables = NULL,
       ...
     ),
     fit$summary(
-      variables = variables, posterior::default_convergence_measures(),
-      .args = list(na.rm = TRUE), ...
+      variables = variables, posterior::default_convergence_measures(), ...
     )
   )
   cbind_custom <- function(x, y) {


### PR DESCRIPTION
This PR drops `na.rm` requirement from some posterior package