### PR TITLE
Feature: @sbfnk comments

### DIFF
--- a/vignettes/germany-age-stratified-nowcasting.Rmd
+++ b/vignettes/germany-age-stratified-nowcasting.Rmd
@@ -85,9 +85,9 @@ latest_nat_germany <- enw_latest_data(latest_nat_germany)
 
 # Data preprocessing
 
-`epinowcast` works by assuming data has been preprocessed into the format it expects. It is at this stage that arbitrary groupings of observations can be defined which will then be propagated throughout all subsequent modelling steps. Here we have data stratified by age and so grouped by age group but in principle this could be any grouping or combination of groups independent of the reference and report date models. Here we also assume a maximum delay required to make the model identifiable. We set this to 40 days due to evidence of long reporting delays in this example data but note that in most cases the majority of right censoring occurs in the first few days and that increasing the maximum delay has a non-linear effect on run-time (i.e a 20 day delay will be much faster to fit a model for than a 40 day delay). Note also that under the current formulation delays longer than the maximum are ignored so that the adjusted estimate is really for data reported after the maximum delay rather than for finally reported data.
+`epinowcast` works by assuming data has been preprocessed into the reporting format it requires coupled with meta data for both reference and report dates. `enw_preprocess_data()` can be used for this though users can also use the internal functions to produce their own custom preprocessing steps. It is at this stage that arbitrary groupings of observations can be defined which will then be propagated throughout all subsequent modelling steps. Here we have data stratified by age and so grouped by age group but in principle this could be any grouping or combination of groups independent of the reference and report date models. Here we also assume a maximum delay required to make the model identifiable. We set this to 40 days due to evidence of long reporting delays in this example data but note that in most cases the majority of right censoring occurs in the first few days and that increasing the maximum delay has a non-linear effect on run-time (i.e a 20 day delay will be much faster to fit a model for than a 40 day delay). Note also that under the current formulation delays longer than the maximum are ignored so that the adjusted estimate is really for data reported after the maximum delay rather than for finally reported data.
 
-Another key modelling choice we make at this stage is to model age groups jointly with aggregated hospitalisations. This implicitly assumes that aggregated and non-aggregated data are not comparable (which may or may not be the case) but that the reporting process shares some of the same mechanisms. Another way to approach this would be to only model age stratified hospitalisations and then to aggregate the nowcast estimates into total counts after fitting the model which assumes that this aggregation is possible.
+Another key modelling choice we make at this stage is to model overall hospitalisations jointly with age groups rather than as an aggregation of age group estimates. This implicitly assumes that aggregated and non-aggregated data are not comparable (which may or may not be the case) but that the reporting process shares some of the same mechanisms. Another way to approach this would be to only model age stratified hospitalisations and then to aggregate the nowcast estimates into total counts after fitting the model.
 
 
 ```r
@@ -144,8 +144,7 @@ plot(nowcast, latest_obs = latest_nat_germany) +
 
 <img src="figures/nowcast-1.png" title="plot of chunk nowcast" alt="plot of chunk nowcast" width="100%" />
 
-In order to identify areas where the current model is poorly reproducing the data we plot the posterior predictions against the data. Here we see fairly clearly oscillations in reported cases every 7 days indicating some kind of week day adjustment may be needed.
-
+In order to identify areas where the current model is poorly reproducing the data we plot the posterior predictions against the data. This plot is facetted age group and reference data with the y axis showing the number of observations reported on a given day for a given reference day and the x axis showing the report date. We see fairly clearly oscillations in reported cases every 7 days which is expressed in the plot by oscillations in each facet that appear to move from left to right across facets. This indicates that some kind of week day adjustment may be needed.
 
 ```r
 plot(nowcast, type = "posterior") +
@@ -1028,8 +1027,7 @@ enw_plot_nowcast_quantiles(
 
 <img src="figures/unnamed-chunk-24-1.png" title="plot of chunk unnamed-chunk-24" alt="plot of chunk unnamed-chunk-24" width="100%" />
 
-As a crude measure of general out of sample performance we can use the leave one out information criterion as supplied by the `loo` package though note this is not typically appropriate for time series data, the approximation used here to avoid refitting is likely to be poor, and we are not accounting for this by refitting the model as required.
-
+As a crude measure of general out of sample performance we can use the leave one out information criterion as supplied by the `loo` package though note this is not typically appropriate for time series data ([where approximate LFO cross validation is likely to perform better](https://cran.r-project.org/web//packages/loo/vignettes/loo2-lfo.html)), the approximation used here to avoid refitting is likely to be poor, and we are not accounting for this by refitting the model as required.
 
 ```r
 loos <- map(nowcasts, ~ .$fit[[1]]$loo())

--- a/vignettes/germany-age-stratified-nowcasting.Rmd.orig
+++ b/vignettes/germany-age-stratified-nowcasting.Rmd.orig
@@ -77,9 +77,9 @@ latest_nat_germany <- enw_latest_data(latest_nat_germany)
 
 # Data preprocessing
 
-`epinowcast` works by assuming data has been preprocessed into the format it expects. It is at this stage that arbitrary groupings of observations can be defined which will then be propagated throughout all subsequent modelling steps. Here we have data stratified by age and so grouped by age group but in principle this could be any grouping or combination of groups independent of the reference and report date models. Here we also assume a maximum delay required to make the model identifiable. We set this to 40 days due to evidence of long reporting delays in this example data but note that in most cases the majority of right censoring occurs in the first few days and that increasing the maximum delay has a non-linear effect on run-time (i.e a 20 day delay will be much faster to fit a model for than a 40 day delay). Note also that under the current formulation delays longer than the maximum are ignored so that the adjusted estimate is really for data reported after the maximum delay rather than for finally reported data.
+`epinowcast` works by assuming data has been preprocessed into the reporting format it requires coupled with meta data for both reference and report dates. `enw_preprocess_data()` can be used for this though users can also use the internal functions to produce their own custom preprocessing steps. It is at this stage that arbitrary groupings of observations can be defined which will then be propagated throughout all subsequent modelling steps. Here we have data stratified by age and so grouped by age group but in principle this could be any grouping or combination of groups independent of the reference and report date models. Here we also assume a maximum delay required to make the model identifiable. We set this to 40 days due to evidence of long reporting delays in this example data but note that in most cases the majority of right censoring occurs in the first few days and that increasing the maximum delay has a non-linear effect on run-time (i.e a 20 day delay will be much faster to fit a model for than a 40 day delay). Note also that under the current formulation delays longer than the maximum are ignored so that the adjusted estimate is really for data reported after the maximum delay rather than for finally reported data.
 
-Another key modelling choice we make at this stage is to model age groups jointly with aggregated hospitalisations. This implicitly assumes that aggregated and non-aggregated data are not comparable (which may or may not be the case) but that the reporting process shares some of the same mechanisms. Another way to approach this would be to only model age stratified hospitalisations and then to aggregate the nowcast estimates into total counts after fitting the model which assumes that this aggregation is possible.
+Another key modelling choice we make at this stage is to model overall hospitalisations jointly with age groups rather than as an aggregation of age group estimates. This implicitly assumes that aggregated and non-aggregated data are not comparable (which may or may not be the case) but that the reporting process shares some of the same mechanisms. Another way to approach this would be to only model age stratified hospitalisations and then to aggregate the nowcast estimates into total counts after fitting the model.
 
 ```{r}
 pobs <- enw_preprocess_data(retro_nat_germany, max_delay = 40, by = "age_group")
@@ -118,7 +118,7 @@ plot(nowcast, latest_obs = latest_nat_germany) +
   facet_wrap(vars(age_group), scales = "free_y")
 ```
 
-In order to identify areas where the current model is poorly reproducing the data we plot the posterior predictions against the data. Here we see fairly clearly oscillations in reported cases every 7 days indicating some kind of week day adjustment may be needed.
+In order to identify areas where the current model is poorly reproducing the data we plot the posterior predictions against the data. This plot is facetted age group and reference data with the y axis showing the number of observations reported on a given day for a given reference day and the x axis showing the report date. We see fairly clearly oscillations in reported cases every 7 days which is expressed in the plot by oscillations in each facet that appear to move from left to right across facets. This indicates that some kind of week day adjustment may be needed.
 
 ```{r simple_pp, fig.width = 36, fig.height = 36, warning = FALSE, message = FALSE}
 plot(nowcast, type = "posterior") +
@@ -448,7 +448,7 @@ enw_plot_nowcast_quantiles(
   facet_grid(vars(age_group), vars(model), scales = "free_y")
 ```
 
-As a crude measure of general out of sample performance we can use the leave one out information criterion as supplied by the `loo` package though note this is not typically appropriate for time series data, the approximation used here to avoid refitting is likely to be poor, and we are not accounting for this by refitting the model as required.
+As a crude measure of general out of sample performance we can use the leave one out information criterion as supplied by the `loo` package though note this is not typically appropriate for time series data ([where approximate LFO cross validation is likely to perform better](https://cran.r-project.org/web//packages/loo/vignettes/loo2-lfo.html)), the approximation used here to avoid refitting is likely to be poor, and we are not accounting for this by refitting the model as required.
 
 ```{r}
 loos <- map(nowcasts, ~ .$fit[[1]]$loo())

--- a/vignettes/model.Rmd
+++ b/vignettes/model.Rmd
@@ -46,7 +46,7 @@ Here we follow the approach of Günther et al.[@gunther2021] and specify the mod
 
 Again following the approach of Günther et al.[@gunther2021] we define the delay distribution ($p_{gtd}$) as a discrete time hazard model ($h_{gtd} =\text{P} \left(\text{delay}=d|\text{delay} \geq d, W_{gtd}\right)$) but we extend this model to decompose $W_{gtd}$ into 3 components: hazard derived from a parametric delay distribution ($\gamma_{gtd}$) dependent on covariates at the date of occurrence, hazard not derived from a parametric distribution ($\delta_{gtd}$) dependent on covariates at the date of occurrence, and hazard dependent on covariates referenced to the date of report ($\epsilon_{gtd}$).
 
-For first component ($\gamma_{gtd}$) we assume that the probability of reporting $p^{\prime}_{gtd}$ given parametric effects on the reference day only follow a parametric distribution (in the baseline case a discretised log normal distribution) with the log mean and log standard deviation being defined using an intercept and arbitrary shared covariates with fixed ($\alpha_{i}$) and random ($\beta_{i}$) coefficients,
+For first component ($\gamma_{gtd}$) we assume that the probability of reporting $p^{\prime}_{gtd}$ on a given date given follow a parametric distribution (in the baseline case a discretised log normal distribution) with the log mean and log standard deviation being defined using an intercept and arbitrary shared, reference date indexed, covariates with fixed ($\alpha_{i}$) and random ($\beta_{i}$) coefficients,
 
 \begin{align}
   p^{\prime}_{gtd} &\sim \text{LogNormal} \left(\mu_{gt}, \upsilon_{gt} \right) \\
@@ -54,13 +54,13 @@ For first component ($\gamma_{gtd}$) we assume that the probability of reporting
   \upsilon_{gt} &= \text{exp} \left( \upsilon_0 + \alpha_{\upsilon} X_{\gamma} + \beta_{\upsilon} Z_{\gamma} \right)
 \end{align}
 
-The parametric logit hazard for this component of the model is then,
+The parametric logit hazard (probability of report on a given date conditional on not already having reported) for this component of the model is then,
 
 \begin{equation}
-  \gamma_{gtd} = \text{logit} \left(\frac{p^{\prime}_{gtd}}{\left(1 -\sum^{d-1}_{d=0} p^{\prime}_{gtd} \right)} \right)
+  \gamma_{gtd} = \text{logit} \left(\frac{p^{\prime}_{gtd}}{\left(1 -\sum^{d-1}_{d^{\prime}=0} p^{\prime}_{gtd^{\prime}} \right)} \right)
 \end{equation}
 
-The non-distributional components for the date of occurrence and report are then again defined using an intercept and arbitrary shared covariates with fixed ($\alpha_{i}$) and random ($\beta_{i}$) coefficients.
+The non-distributional logit hazarad components for the date of occurrence and report are then again defined using an intercept and arbitrary shared covariates with fixed ($\alpha_{i}$) and random ($\beta_{i}$) coefficients.
 
 \begin{align}
   \delta_{gtd} &= \mu_0 + \alpha_{\delta} X_{\delta} + \beta_{\delta} Z_{\delta} \\
@@ -73,10 +73,10 @@ The overall hazard for each group, occurrence time, and delay is then,
   \text{logit} (h_{gtd}) = \gamma_{gtd} + \delta_{gtd} +  \upsilon_{gtd},\ h_{gtD} = 1
 \end{equation}
 
-and so the probability of report for a given delay, occurrence date, and group is as follows.
+where the hazard on the final day has been assumed to be 1 in order to enforce the constraint that all reported observations are reported within the specified maximum delay. The probability of report for a given delay, occurrence date, and group is then as follows,
 
 \begin{equation}
-  p_{gt0} = h_{gt0},\ p_{gtd} = \left(1 -\sum^{d-1}_{d=0} p_{gtd} \right) \times h_{gtd}
+  p_{gt0} = h_{gt0},\ p_{gtd} = \left(1 -\sum^{d-1}_{d^{\prime}=0} p_{gtd^{\prime}} \right) \times h_{gtd}
 \end{equation}
 
 All ($\alpha_{i}$) and random ($\beta_{i}$) coefficients have standard normal priors by default with standard half-normal priors for pooled standard deviations.


### PR DESCRIPTION
This PR adds changes based on recent comments from @sbfnk. These changes are:

- Update the hazard to probabiltiy and probability to hazard equations to use improved notation
- Adding text explaining the use of `enw_preprocess_data()`
- Adding text giving more context for the posterior plots
- Adding additional text highlighting that the approximate leave one out information criterion is not a principled measure for this use case and providing a link out to the approximate leave future out cross validation vignette. 
- Adding text to explain the logit hazard step in more detail and to clarify the statement that the final hazard is 1. 