### PR TITLE
Bug: Fix presence of duplicate summarise samples

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: epinowcast
 Title: Hierarchical Nowcasting of Right Censored Epidemiological Counts
-Version: 0.0.3.3000
+Version: 0.0.3.4000
 Authors@R:
     c(person(given = "Sam Abbott",
              role = c("aut", "cre"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
 * Update read me quick start to use 40 days of delay vs 30
 * Add a section to the read me quick start showing an example of handling nowcast samples.
 * Add support for passing custom models and included files to `enw_model()`.
+* Fix a bug where `enw_summarise_samples()` returned duplicate samples.
 
 # epinowcast 0.0.3
 

--- a/R/postprocess.R
+++ b/R/postprocess.R
@@ -167,7 +167,7 @@ enw_summarise_samples <- function(samples, probs = c(
       quantile(sample, probs, na.rm = TRUE)
     ),
     by = by
-  ])
+  ][, sample := NULL])
 
   summary <- purrr::reduce(
     list(obs, summary, quantiles), merge,


### PR DESCRIPTION
This PR fixes a bug which led to duplicated summarised samples when samples were summarised manually vs using `cmdstanr`.