### PR TITLE
Update CmdStan version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -63,4 +63,4 @@ Language: en-GB
 LazyData: true
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.2.9000
-SystemRequirements: CmdStan (>=2.28)
+SystemRequirements: CmdStan (>=2.29)


### PR DESCRIPTION
Since we added code optimization with stanc, we require CmdStan 2.29 at least.