### PR TITLE
Vectorise hazard_to_prob

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: epinowcast
 Title: Hierarchical Nowcasting of Right Censored Epidemiological Counts
-Version: 0.0.6.2000
+Version: 0.0.6.3000
 Authors@R:
   c(person(given = "Sam Abbott",
            role = c("aut", "cre"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 * Add profiling switch to model compilation, allowing to toggle profiling (https://mc-stan.org/cmdstanr/articles/profiling.html) on/off in the same model (see [#41](https://github.com/epiforecasts/epinowcast/pull/41) by [@adrian-lison](https://github.com/adrian-lison)).
 * Fully vectorise the likelihood by flattening observations and pre-specify expected observations into a vector before calculating the log-likelihood (see [#40](https://github.com/epiforecasts/epinowcast/pull/40) by [@seabbs](https://github.com/seabbs)).
 * Adds vectorisation of zero truncated normal distributions (see [#38](https://github.com/epiforecasts/epinowcast/pull/38) by [@seabbs](https://github.com/seabbs))
+* `hazard_to_prob` has been optimised using vectorisation (see [#53] by [@adrian-lison](https://github.com/adrian-lison) and [@seabbs](https://github.com/seabbs)).
+* `prob_to_hazard` has been optimised so that only required cumulative probabilties are calculated (see [#53] by [@adrian-lison](https://github.com/adrian-lison) and [@seabbs](https://github.com/seabbs)).
 
 # epinowcast 0.0.5
 

--- a/inst/stan/functions/hazard.stan
+++ b/inst/stan/functions/hazard.stan
@@ -12,8 +12,10 @@ vector prob_to_hazard(vector p) {
 
 vector cumulative_converse_hazard(vector h) {
   int l = num_elements(h);
+  vector[l] h_shifted;
+  h_shifted = append_row(rep_vector(0.0,1),h[1:(l-1)]);
   vector[l] ch;
-  ch = log1m(h);
+  ch = log1m(h_shifted);
   ch = cumulative_sum(ch);
   ch = exp(ch);
   return(ch);
@@ -21,13 +23,7 @@ vector cumulative_converse_hazard(vector h) {
 
 vector hazard_to_prob(vector h) {
   int l = num_elements(h);
-  int i = l - 1;
   vector[l] p;
-  p[1] = h[1]; 
-  if (i) {
-    vector[i] ch;
-    ch = cumulative_converse_hazard(h[1:i]);
-    p[2:l] = h[2:l] .* ch;
-  }
+  p[1:l] = h[1:l] .* cumulative_converse_hazard(h[1:l]);
   return(p);
 }

--- a/inst/stan/functions/hazard.stan
+++ b/inst/stan/functions/hazard.stan
@@ -13,7 +13,10 @@ vector prob_to_hazard(vector p) {
 vector cumulative_converse_hazard(vector h) {
   int l = num_elements(h);
   vector[l] h_shifted;
-  h_shifted = append_row(rep_vector(0.0,1),h[1:(l-1)]);
+  h_shifted[1] = 0;
+  if (l > 1) {
+    h_shifted[2:l] = h[1:(l-1)];
+  }
   vector[l] ch;
   ch = log1m(h_shifted);
   ch = cumulative_sum(ch);

--- a/inst/stan/functions/hazard.stan
+++ b/inst/stan/functions/hazard.stan
@@ -1,21 +1,33 @@
 vector prob_to_hazard(vector p) {
   int l = num_elements(p);
+  int i = l - 1;
   vector[l] h;
-  vector[l + 1] cum_p;
+  vector[i] cum_p;
   cum_p[1] = 0;
-  cum_p[2:(l+1)] = cumulative_sum(p);
-  h[1:(l-1)] = p[1:(l-1)] ./ (1 - cum_p[1:(l-1)]);
+  cum_p[2:i] = cumulative_sum(p[1:(i-1)]);
+  h[1:i] = p[1:i] ./ (1 - cum_p);
   h[l] = 1;
   return(h);
 }
 
+vector cumulative_converse_hazard(vector h) {
+  int l = num_elements(h);
+  vector[l] ch;
+  ch = log1m(h);
+  ch = cumulative_sum(ch);
+  ch = exp(ch);
+  return(ch);
+}
+
 vector hazard_to_prob(vector h) {
   int l = num_elements(h);
+  int i = l - 1;
   vector[l] p;
-  real p_sum = 0;
-  for (i in 1:l) { 
-    p[i] = (1 - p_sum) * h[i];
-    p_sum += p[i];
+  p[1] = h[1]; 
+  if (i) {
+    vector[i] ch;
+    ch = cumulative_converse_hazard(h[1:i]);
+    p[2:l] = h[2:l] .* ch;
   }
   return(p);
 }


### PR DESCRIPTION
This PR makes use of ideas from @adrian-lison and implemented [here](https://github.com/adrian-lison/nowcast-transmission/blob/main/code/models/functions/helper_functions.stan) to vectorise `hazard_to_prob`. It differs from this implementation in two ways. Firstly it does not assume the complete hazard is available (due to this not being the case in the likelihood call) and therefore does not optimise the probability at the maximum delay. Secondly, it makes use of `log1m` for a slight performance boost and numerical stability. 

It also adds slight optimisations to `prob_to_hazard` so that only required cumulative probabilities are calculated. 

Initial testing suggests this gives a small speedup at the cost of slightly less clear code. 