### PR TITLE
Feature missing reference dates

### DIFF
--- a/R/model.R
+++ b/R/model.R
@@ -19,7 +19,9 @@ enw_priors <- function() {
       "logmean_sd",
       "logsd_sd",
       "rd_eff_sd",
-      "sqrt_phi"
+      "sqrt_phi",
+      "alpha_start",
+      "alpha_sd"
     ),
     description = c(
       "Standard deviation for expected final observations",
@@ -28,7 +30,9 @@ enw_priors <- function() {
       "Standard deviation of scaled pooled logmean effects",
       "Standard deviation of scaled pooled logsd effects",
       "Standard deviation of scaled pooled report date effects",
-      "One over the square of the reporting overdispersion"
+      "One over the square of the reporting overdispersion",
+      "Logit start value for share of cases with known reference date",
+      "Standard deviation of random walk for share of cases with known reference date"
     ),
     distribution = c(
       "Zero truncated normal",
@@ -37,10 +41,12 @@ enw_priors <- function() {
       "Zero truncated normal",
       "Zero truncated normal",
       "Zero truncated normal",
+      "Zero truncated normal",
+      "Normal",
       "Zero truncated normal"
     ),
-    mean = c(0, 1, 0.5, rep(0, 4)),
-    sd = rep(1, 7)
+    mean = c(0, 1, 0.5, rep(0, 4), 0, 0),
+    sd = c(rep(1, 7), 1, 0.1)
   )
 }
 

--- a/R/preprocess.R
+++ b/R/preprocess.R
@@ -138,9 +138,9 @@ enw_retrospective_data <- function(obs, rep_date, rep_days, ref_date,
   retro_data <- retro_data[report_date <= rep_date]
 
   if (!missing(ref_days)) {
-    ref_date <- max(retro_data$reference_date) - ref_days
+    ref_date <- max(retro_data$reference_date, na.rm = TRUE) - ref_days
   }
-  retro_data <- retro_data[reference_date >= ref_date]
+  retro_data <- retro_data[reference_date >= ref_date | is.na(reference_date)]
   return(retro_data[])
 }
 

--- a/R/preprocess.R
+++ b/R/preprocess.R
@@ -273,8 +273,8 @@ enw_preprocess_data <- function(obs, by = c(), max_delay = 20,
   # complete missing report dates
   comp <- rbind(
     obs[!is.na(reference_date)][rep(1:.N,each=max_delay), .(report_date = reference_date + 0:(.N - 1)), by = c("reference_date", "group")],
-    CJ(reference_date = as.Date(NA), group = unique(obs[,group]), report_date = obs[,seq.Date(pmin(min(report_date,na.rm=T),min(reference_date,na.rm=T)),
-                                                                                              pmin(max(report_date,na.rm=T),max(reference_date,na.rm=T)),by=1)])
+    CJ(reference_date = as.Date(NA), group = unique(obs[,group]), report_date = obs[,seq.Date(min(reference_date,na.rm=T),
+                                                                                              max(reference_date,na.rm=T)+max_delay-1,by=1)])
   )
   grouping_factors <- obs[, lapply(.SD, min, na.rm = TRUE), .SDcols = by, by = "group"]
   comp <- comp[grouping_factors, on = "group"]

--- a/R/preprocess.R
+++ b/R/preprocess.R
@@ -281,12 +281,12 @@ enw_preprocess_data <- function(obs, by = c(), max_delay = 20,
   obs <- obs[comp, on = c("reference_date", "group", "report_date", by)]
   obs[, confirm:=nafill(nafill(confirm, "locf"), fill = 0), by = c("reference_date", "group")]
   
-  # filter by maximum report date
+  # filter by maximum reporting delay
   obs <- obs[, .SD[report_date <= (reference_date + max_delay - 1) | is.na(reference_date)],
     by = c("reference_date", "group")
   ]
 
-  # difference reports and filter for max delay an report date
+  # difference reports and filter for max delay and report date
   diff_obs <- enw_new_reports(obs)
 
   if (set_negatives_to_zero) {

--- a/R/preprocess.R
+++ b/R/preprocess.R
@@ -34,7 +34,7 @@ enw_add_metaobs_features <- function(metaobs, holidays = c(),
   metaobs <- data.table::copy(metaobs)
   metaobs[, day_of_week := weekdays(date)]
 
-  # make holidays be sundays
+  # make holidays be Sundays
   if (length(holidays) != 0) {
     metaobs[get(holidays) == TRUE, day_of_week := holidays_to]
   }

--- a/R/preprocess.R
+++ b/R/preprocess.R
@@ -94,6 +94,9 @@ enw_extend_date <- function(metaobs, max_delay = 20) {
 #' @export
 #' @importFrom data.table as.data.table copy
 enw_assign_group <- function(obs, by = c()) {
+  if ("group" %in% names(obs)) {
+    stop("Dataset cannot have a column called 'group'.")
+  }
   obs <- data.table::as.data.table(obs)
   if (length(by) == 0) {
     obs <- obs[, group := 1]

--- a/inst/stan/epinowcast.stan
+++ b/inst/stan/epinowcast.stan
@@ -38,7 +38,7 @@ data {
   // Observations
   int obs[s, dmax]; // obs for each primary date (row) and report date (column)
   int flat_obs[n]; // obs stored as a flat vector
-  int obs_miss[dmax]; // obs with missing primary date
+  int obs_miss[g, rd]; // obs with missing primary date (group first)
   int latest_obs[t, g]; // latest obs for each snapshot group
   // Control parameters
   int debug; // should debug information be shown
@@ -187,8 +187,8 @@ model {
   // log density: observed vs model
   if (likelihood) {
     profile("model_likelihood") {
-    target += obs_lupmf(flat_obs | sl, csl, imp_obs, sg, st,
-                         rdlurd, srdlh, ref_lh, dpmfs, ref_p, phi);
+    target += obs_lupmf(flat_obs | obs_miss, dmax, sl, csl, g, imp_obs, sg, st,
+                         rdlurd, srdlh, ref_lh, dpmfs, ref_p, alpha, phi);
     }
   }
 }

--- a/inst/stan/epinowcast.stan
+++ b/inst/stan/epinowcast.stan
@@ -169,7 +169,7 @@ model {
   // log density: observed vs model
   if (likelihood) {
     profile("model_likelihood") {
-    target += reduce_sum(obs_lupmf, st, 1, flat_obs, sl, csl, imp_obs, sg, st,
+    target += obs_lupmf(flat_obs | sl, csl, imp_obs, sg, st,
                          rdlurd, srdlh, ref_lh, dpmfs, ref_p, phi);
     }
   }

--- a/inst/stan/epinowcast.stan
+++ b/inst/stan/epinowcast.stan
@@ -197,7 +197,7 @@ generated quantities {
   int pp_obs[pp ? sum(sl) : 0];
   int pp_obs_miss[pp ? sum(sl) : 0];
   vector[ologlik ? s : 0] log_lik;
-  vector[ologlik ? t : 0] log_lik_miss;
+  vector[ologlik ? (t-dmax) : 0] log_lik_miss;
   int pp_inf_obs[cast ? dmax : 0, cast ? g : 0];
   int pp_inf_obs_miss[cast ? t : 0, cast ? g : 0];
   int pp_inf_obs_miss_rep[cast ? (t-dmax) : 0, cast ? g : 0];
@@ -248,10 +248,10 @@ generated quantities {
     profile("generated_loglik") {
     if (ologlik) {
       for (i in (dmax+1):t) {
-        log_lik_miss[i] = 0;
+        log_lik_miss[i - dmax] = 0;
         for (k in 1:g) {
           // log-likelihood for observations with missing reference date
-          log_lik_miss[i] += neg_binomial_2_lpmf(
+          log_lik_miss[i - dmax] += neg_binomial_2_lpmf(
             obs_miss[k, i] | exp_obs_miss_rep[k][i], phi);
         }
       }

--- a/inst/stan/epinowcast.stan
+++ b/inst/stan/epinowcast.stan
@@ -80,7 +80,7 @@ parameters {
   vector<lower=0>[neff_sds] logsd_sd; // pooled modifiers to logsd
   vector<lower=0>[nrd_eff_sds] rd_eff_sd; // pooled modifiers to report date
   real alpha_start[g]; // starting value for alpha
-  real alpha_sd; // standard deviation of the random walk increments
+  real<lower=0> alpha_sd; // standard deviation of the random walk increments
   vector<offset=0, multiplier=alpha_sd>[t] alpha_epsilon[g]; // random walk increments, non-centered
   real<lower=0, upper=1e4> sqrt_phi; // Overall dispersion by group
 }
@@ -138,7 +138,7 @@ transformed parameters{
   // estimate share of cases with eventually known reference date, modeled as
   // a first order random walk for each group on the logit scale
   for (k in 1:g) {
-    alpha[k] = logit(alpha_start[k] + cumulative_sum(alpha_epsilon[k]));
+    alpha[k] = inv_logit(alpha_start[k] + cumulative_sum(alpha_epsilon[k]));
   }
   // transform phi to overdispersion scale
   phi = 1 / sqrt(sqrt_phi);

--- a/inst/stan/epinowcast.stan
+++ b/inst/stan/epinowcast.stan
@@ -38,7 +38,7 @@ data {
   // Observations
   int obs[s, dmax]; // obs for each primary date (row) and report date (column)
   int flat_obs[n]; // obs stored as a flat vector
-  int obs_miss[g, rd]; // obs with missing primary date (group first)
+  int obs_miss[g, t]; // obs with missing primary date (group first)
   int latest_obs[t, g]; // latest obs for each snapshot group
   // Control parameters
   int debug; // should debug information be shown
@@ -200,14 +200,14 @@ generated quantities {
   vector[ologlik ? rd : 0] log_lik_miss;
   int pp_inf_obs[cast ? dmax : 0, cast ? g : 0];
   int pp_inf_obs_miss[cast ? t : 0, cast ? g : 0];
-  int pp_inf_obs_miss_rep[cast ? rd : 0, cast ? g : 0];
+  int pp_inf_obs_miss_rep[cast ? t : 0, cast ? g : 0];
   profile("generated_total") {
   if (cast) {
     int i_group, i_time;
     real tar_obs, tar_alpha;
     vector[dmax] rdlh;
     vector[dmax] exp_obs;
-    vector[ologlik ? rd : 0] exp_obs_miss_rep[ologlik ? g : 0] = rep_array(rep_vector(0, rd), g);
+    vector[ologlik ? t : 0] exp_obs_miss_rep[ologlik ? g : 0] = rep_array(rep_vector(0, t), g);
     int pp_obs_tmp[s, dmax];
     int pp_obs_tmp_miss[s, dmax];
     // Posterior predictions for observations
@@ -233,7 +233,7 @@ generated quantities {
       }
     }
     profile("generated_loglik") {
-    for (i in (1+dmax):rd) {
+    for (i in (1+dmax):t) {
       log_lik_miss[i] = 0;
       for (k in 1:g) {
         log_lik_miss[i] += neg_binomial_2_lpmf(obs_miss[k, i] | exp_obs_miss_rep[k][i], phi);
@@ -258,7 +258,7 @@ generated quantities {
         pp_inf_obs_miss[i, k] = sum(pp_obs_tmp_miss[snap, 1:dmax]);
       }
       // cases with missing reference date (by reporting date)
-      pp_inf_obs_miss_rep = rep_array(0, rd, g);
+      pp_inf_obs_miss_rep = rep_array(0, t, g);
       for (i in dmax:rd) {
         int snap = ts[i, k];
         for (l in 1:dmax){

--- a/inst/stan/epinowcast.stan
+++ b/inst/stan/epinowcast.stan
@@ -135,7 +135,7 @@ transformed parameters{
     imp_obs[k] = exp(imp_obs[k]);
   }
   }
-  // estimate share of cases with eventually known onset date, modeled as
+  // estimate share of cases with eventually known reference date, modeled as
   // a first order random walk for each group on the logit scale
   for (k in 1:g) {
     alpha[k] = logit(alpha_start[k] + cumulative_sum(alpha_epsilon[k]));
@@ -175,7 +175,7 @@ model {
       rd_eff_sd ~ zero_truncated_normal(rd_eff_sd_p[1], rd_eff_sd_p[2]);
     } 
   }
-  // share of cases with eventually known onset date
+  // share of cases with eventually known reference date
   alpha_sd ~ normal(alpha_sd_p[1], alpha_sd_p[2]) T[0, ];
   for (k in 1:g){
     alpha_start[k] ~ normal(alpha_start_p[1], alpha_start_p[2]);

--- a/inst/stan/epinowcast.stan
+++ b/inst/stan/epinowcast.stan
@@ -87,6 +87,7 @@ transformed parameters{
   matrix[dmax, npmfs] ref_lh; // sparse report logit hazards
   vector[urds] srdlh; // sparse report day logit hazards
   vector[t] imp_obs[g]; // Expected final observations
+  vector<lower=0,upper=1>[t] alpha[g]; // share of cases with known reference date
   real phi; // Transformed overdispersion (joint across all observations)
   // calculate log mean and sd parameters for each dataset from design matrices
   profile("transformed_delay_reference_date_total") {

--- a/inst/stan/epinowcast.stan
+++ b/inst/stan/epinowcast.stan
@@ -259,9 +259,11 @@ generated quantities {
       }
       // cases with missing reference date (by reporting date)
       pp_inf_obs_miss_rep = rep_array(0, rd, g);
-      for (i in (1+dmax):rd) {
+      for (i in dmax:rd) {
         int snap = ts[i, k];
-        pp_inf_obs_miss_rep[max(1 + dmax, i):(i + dmax), i_group] = pp_obs_tmp_miss[snap, max(1 + dmax - i, 1):dmax];
+        for (l in 1:dmax){
+          pp_inf_obs_miss_rep[i + l, i_group] += pp_obs_tmp_miss[snap, l];
+        }
       }
     }
     // If posterior predictions for all observations are needed copy

--- a/inst/stan/epinowcast.stan
+++ b/inst/stan/epinowcast.stan
@@ -19,10 +19,6 @@ data {
   int csl[s]; // cumulative version of the above
   int sg[s]; // how snapshots are related
   int dmax; // maximum possible report date
-  // Observations
-  int obs[s, dmax]; // obs for each primary date (row) and report date (column)
-  int flat_obs[n]; // obs stored as a flat vector
-  int latest_obs[t, g]; // latest obs for each snapshot group
   // Reference day model
   int npmfs; // how many unique pmfs there are
   int dpmfs[s]; // how each date links to a pmf
@@ -39,6 +35,11 @@ data {
   matrix[urds, nrd_effs + 1] rd_fixed; // design matrix for report dates
   int nrd_eff_sds; // number of standard deviations to use for pooling for rds
   matrix[nrd_effs, nrd_eff_sds + 1] rd_random; // Pooling pmf design matrix 
+  // Observations
+  int obs[s, dmax]; // obs for each primary date (row) and report date (column)
+  int flat_obs[n]; // obs stored as a flat vector
+  int obs_miss[dmax]; // obs with missing primary date
+  int latest_obs[t, g]; // latest obs for each snapshot group
   // Control parameters
   int debug; // should debug information be shown
   int likelihood; // should the likelihood be included

--- a/inst/stan/functions/obs_lpmf.stan
+++ b/inst/stan/functions/obs_lpmf.stan
@@ -7,10 +7,8 @@ real obs_lpmf(int[] obs, int[,] obs_miss, int dmax, int[] sl, int[] csl, int n_g
   int n_snaps = num_elements(st);
   int n_obs = num_elements(obs);
   int n_obs_miss = num_elements(obs_miss[1]);
-  vector[n_obs] exp_obs_all;
   vector[n_obs] exp_obs;
   vector[n_obs_miss] exp_obs_miss[n_groups] = rep_array(rep_vector(0, n_obs_miss), n_groups);
-  
   int g, t, l;
   int ssnap = 1;
   int esnap = 0;
@@ -28,13 +26,13 @@ real obs_lpmf(int[] obs, int[,] obs_miss, int dmax, int[] sl, int[] csl, int n_g
     tar_alpha = alpha[g][t];
     // combine expected final obs and date effects to get expected obs
     esnap += l;
-    exp_obs_all[ssnap:esnap] = expected_obs(
+    vector[l] exp_obs_all = expected_obs(
       tar_obs, ref_lh[1:l, dpmfs[i]], rdlh, ref_p
     );
     // compute expected final obs with known and missing reference date
     exp_obs[ssnap:esnap] = exp_obs_all * tar_alpha;
-    if(t+l>=1+dmax){
-      exp_obs_miss[g][max(1 + dmax, t):(t + l)] += exp_obs_all[max(1 + dmax - t, 1):l] * (1 - tar_alpha);
+    if(t+l-1>=1+dmax){
+      exp_obs_miss[g][max(1 + dmax, t):(t + l - 1)] += exp_obs_all[max(2 + dmax - t, 1):l] * (1 - tar_alpha);
     }
     ssnap += l;
   }

--- a/inst/stan/functions/obs_lpmf.stan
+++ b/inst/stan/functions/obs_lpmf.stan
@@ -32,14 +32,16 @@ real obs_lpmf(int[] obs, int[,] obs_miss, int dmax, int[] sl, int[] csl, int n_g
     );
     // compute expected final obs with known and missing reference date
     exp_obs[ssnap:esnap] = exp_obs * tar_alpha;
-    exp_obs_miss[g][t:(t + l)] = exp_obs * (1-tar_alpha);
+    if(t+l>=1+dmax){
+      exp_obs_miss[g][max(1+dmax,t):(t + l)] = exp_obs[max(1+dmax-t,1):l] * (1-tar_alpha);
+    }
     ssnap += l;
   }
   // observation error model with known reference dates (across all reference times and groups)
   tar = neg_binomial_2_lupmf(obs | exp_obs, phi);
   // observation error model with missing reference dates
   for (k in 1:n_groups) {
-    tar += neg_binomial_2_lupmf(obs_miss[k] | exp_obs_miss[k], phi);
+    tar += neg_binomial_2_lupmf(obs_miss[k][(1+dmax):n_obs_miss] | exp_obs_miss[k][(1+dmax):n_obs_miss], phi);
   }
   return(tar);
-}
+}]

--- a/inst/stan/functions/obs_lpmf.stan
+++ b/inst/stan/functions/obs_lpmf.stan
@@ -1,9 +1,10 @@
-real obs_lpmf(int[] dummy, int start, int end, int[] obs, int[] sl, int[] csl,
+real obs_lpmf(int[] obs, int[] sl, int[] csl,
               vector[] imp_obs, int[] sg, int[] st, int[,] rdlurd,
               vector srdlh, matrix ref_lh, int[] dpmfs, int ref_p, real phi) {
+  int end = num_elements(st);
   real tar = 0;
   real tar_obs;
-  int start_n = csl[start] - sl[start];
+  int start_n = csl[1] - sl[1];
   int end_n = csl[end];
   int n = end_n - start_n;
   int snap_obs[n] = obs[(start_n + 1):end_n];
@@ -12,7 +13,7 @@ real obs_lpmf(int[] dummy, int start, int end, int[] obs, int[] sl, int[] csl,
   int ssnap = 1;
   int esnap = 0;
 
-  for (i in start:end) {
+  for (i in 1:end) {
     g = sg[i];
     t = st[i];
     l = sl[i];

--- a/inst/stan/functions/obs_lpmf.stan
+++ b/inst/stan/functions/obs_lpmf.stan
@@ -1,11 +1,15 @@
-real obs_lpmf(int[] obs, int[] sl, int[] csl,
+real obs_lpmf(int[] obs, int[,] obs_miss, int dmax, int[] sl, int[] csl, int n_groups,
               vector[] imp_obs, int[] sg, int[] st, int[,] rdlurd,
-              vector srdlh, matrix ref_lh, int[] dpmfs, int ref_p, real phi) {
+              vector srdlh, matrix ref_lh, int[] dpmfs, int ref_p, vector[] alpha, real phi) {
   real tar = 0;
   real tar_obs;
+  real tar_alpha;
   int n_snaps = num_elements(st);
   int n_obs = num_elements(obs);
+  int n_obs_miss = num_elements(obs_miss[1]);
+  vector[n_obs] exp_obs_all;
   vector[n_obs] exp_obs;
+  vector[n_obs_miss] exp_obs_miss[n_groups];
   int g, t, l;
   int ssnap = 1;
   int esnap = 0;
@@ -19,14 +23,23 @@ real obs_lpmf(int[] obs, int[] sl, int[] csl,
     tar_obs = imp_obs[g][t];
     // allocate report day effects
     rdlh = srdlh[rdlurd[t:(t + l - 1), g]];
+    // allocate share of cases with known reference date
+    tar_alpha = alpha[g][t];
     // combine expected final obs and date effects to get expected obs
     esnap += l;
-    exp_obs[ssnap:esnap] = expected_obs(
+    exp_obs_all[ssnap:esnap] = expected_obs(
       tar_obs, ref_lh[1:l, dpmfs[i]], rdlh, ref_p
     );
+    // compute expected final obs with known and missing reference date
+    exp_obs[ssnap:esnap] = exp_obs * tar_alpha;
+    exp_obs_miss[g][t:(t + l)] = exp_obs * (1-tar_alpha);
     ssnap += l;
   }
-  // observation error model (across all reference times and groups)
+  // observation error model with known reference dates (across all reference times and groups)
   tar = neg_binomial_2_lupmf(obs | exp_obs, phi);
+  // observation error model with missing reference dates
+  for (k in 1:n_groups) {
+    tar += neg_binomial_2_lupmf(obs_miss[k] | exp_obs_miss[k], phi);
+  }
   return(tar);
 }

--- a/inst/stan/functions/obs_lpmf.stan
+++ b/inst/stan/functions/obs_lpmf.stan
@@ -1,19 +1,16 @@
 real obs_lpmf(int[] obs, int[] sl, int[] csl,
               vector[] imp_obs, int[] sg, int[] st, int[,] rdlurd,
               vector srdlh, matrix ref_lh, int[] dpmfs, int ref_p, real phi) {
-  int end = num_elements(st);
   real tar = 0;
   real tar_obs;
-  int start_n = csl[1] - sl[1];
-  int end_n = csl[end];
-  int n = end_n - start_n;
-  int snap_obs[n] = obs[(start_n + 1):end_n];
-  vector[n] exp_obs;
+  int n_snaps = num_elements(st);
+  int n_obs = num_elements(obs);
+  vector[n_obs] exp_obs;
   int g, t, l;
   int ssnap = 1;
   int esnap = 0;
 
-  for (i in 1:end) {
+  for (i in 1:n_snaps) {
     g = sg[i];
     t = st[i];
     l = sl[i];
@@ -30,6 +27,6 @@ real obs_lpmf(int[] obs, int[] sl, int[] csl,
     ssnap += l;
   }
   // observation error model (across all reference times and groups)
-  tar = neg_binomial_2_lupmf(snap_obs | exp_obs, phi);
+  tar = neg_binomial_2_lupmf(obs | exp_obs, phi);
   return(tar);
 }

--- a/inst/stan/functions/obs_lpmf.stan
+++ b/inst/stan/functions/obs_lpmf.stan
@@ -9,7 +9,8 @@ real obs_lpmf(int[] obs, int[,] obs_miss, int dmax, int[] sl, int[] csl, int n_g
   int n_obs_miss = num_elements(obs_miss[1]);
   vector[n_obs] exp_obs_all;
   vector[n_obs] exp_obs;
-  vector[n_obs_miss] exp_obs_miss[n_groups];
+  vector[n_obs_miss] exp_obs_miss[n_groups] = rep_array(rep_vector(0, n_obs_miss), n_groups);
+  
   int g, t, l;
   int ssnap = 1;
   int esnap = 0;
@@ -31,9 +32,9 @@ real obs_lpmf(int[] obs, int[,] obs_miss, int dmax, int[] sl, int[] csl, int n_g
       tar_obs, ref_lh[1:l, dpmfs[i]], rdlh, ref_p
     );
     // compute expected final obs with known and missing reference date
-    exp_obs[ssnap:esnap] = exp_obs * tar_alpha;
+    exp_obs[ssnap:esnap] = exp_obs_all * tar_alpha;
     if(t+l>=1+dmax){
-      exp_obs_miss[g][max(1+dmax,t):(t + l)] = exp_obs[max(1+dmax-t,1):l] * (1-tar_alpha);
+      exp_obs_miss[g][max(1 + dmax, t):(t + l)] += exp_obs_all[max(1 + dmax - t, 1):l] * (1 - tar_alpha);
     }
     ssnap += l;
   }
@@ -41,7 +42,7 @@ real obs_lpmf(int[] obs, int[,] obs_miss, int dmax, int[] sl, int[] csl, int n_g
   tar = neg_binomial_2_lupmf(obs | exp_obs, phi);
   // observation error model with missing reference dates
   for (k in 1:n_groups) {
-    tar += neg_binomial_2_lupmf(obs_miss[k][(1+dmax):n_obs_miss] | exp_obs_miss[k][(1+dmax):n_obs_miss], phi);
+    tar += neg_binomial_2_lupmf(obs_miss[k][(1 + dmax):n_obs_miss] | exp_obs_miss[k][(1 + dmax):n_obs_miss], phi);
   }
   return(tar);
-}]
+}


### PR DESCRIPTION
This is a WIP draft pull request for the missing reference date feature. It implements only the absolute minimum to get a running model, i.e. the preprocessing and the minimal running version of the stan model. No postprocessing yet. I have tested the model with simulated data (see vignette draft in extra dev branch "missing_reference_vignette_wip") and it seems to be working fine. I will add a couple of comments to the coding decisions and add remarks on currently missing extensions that are planned for the MVP.