### PR TITLE
Replace group with .group

### DIFF
--- a/R/model-design-tools.R
+++ b/R/model-design-tools.R
@@ -187,7 +187,7 @@ enw_add_cumulative_membership <- function(metaobs, feature) {
     cfeatures <- grep(cfeature, colnames(metaobs), value = TRUE)
     metaobs[,
       (cfeatures) := purrr::map(.SD, ~ ifelse(cumsum(.) > 0, 1, 0)),
-      .SDcols = cfeatures, by = "group"
+      .SDcols = cfeatures, by = ".group"
     ]
   }
   return(metaobs[])

--- a/R/model.R
+++ b/R/model.R
@@ -55,14 +55,14 @@ enw_obs_as_data_list <- function(pobs) {
   # format latest matrix
   latest_matrix <- pobs$latest[[1]]
   latest_matrix <- data.table::dcast(
-    latest_matrix, reference_date ~ group,
+    latest_matrix, reference_date ~ .group,
     value.var = "confirm"
   )
   latest_matrix <- as.matrix(latest_matrix[, -1])
 
   # get new confirm for processing
   new_confirm <- data.table::copy(pobs$new_confirm[[1]])
-  data.table::setorderv(new_confirm, c("reference_date", "group", "delay"))
+  data.table::setorderv(new_confirm, c("reference_date", ".group", "delay"))
 
   # get flat observations
   flat_obs <- new_confirm$new_confirm
@@ -70,22 +70,22 @@ enw_obs_as_data_list <- function(pobs) {
   # format vector of snapshot lengths
   snap_length <- new_confirm
   snap_length <- snap_length[, .SD[delay == max(delay)],
-    by = c("reference_date", "group")
+    by = c("reference_date", ".group")
   ]
   snap_length <- snap_length$delay + 1
 
   # snap lookup
-  snap_lookup <- unique(new_confirm[, .(reference_date, group)])
+  snap_lookup <- unique(new_confirm[, .(reference_date, .group)])
   snap_lookup[, s := 1:.N]
   snap_lookup <- data.table::dcast(
-    snap_lookup, reference_date ~ group,
+    snap_lookup, reference_date ~ .group,
     value.var = "s"
   )
   snap_lookup <- as.matrix(snap_lookup[, -1])
 
   # snap time
-  snap_time <- unique(new_confirm[, .(reference_date, group)])
-  snap_time[, t := 1:.N, by = "group"]
+  snap_time <- unique(new_confirm[, .(reference_date, .group)])
+  snap_time[, t := 1:.N, by = ".group"]
   snap_time <- snap_time$t
 
   # Format indexing and observed data
@@ -99,7 +99,7 @@ enw_obs_as_data_list <- function(pobs) {
     ts = snap_lookup,
     sl = snap_length,
     csl = cumsum(snap_length),
-    sg = unique(new_confirm[, .(reference_date, group)])$group,
+    sg = unique(new_confirm[, .(reference_date, .group)])$.group,
     dmax = pobs$max_delay[[1]],
     obs = as.matrix(pobs$reporting_triangle[[1]][, -c(1:2)]),
     flat_obs = flat_obs,

--- a/R/postprocess.R
+++ b/R/postprocess.R
@@ -76,16 +76,16 @@ enw_nowcast_summary <- function(fit, obs,
     probs = probs
   )
 
-  max_delay <- nrow(nowcast) / max(obs$group)
+  max_delay <- nrow(nowcast) / max(obs$.group)
 
   ord_obs <- data.table::copy(obs)
   ord_obs <- ord_obs[reference_date > (max(reference_date) - max_delay)]
-  data.table::setorderv(ord_obs, c("group", "reference_date"))
+  data.table::setorderv(ord_obs, c(".group", "reference_date"))
   nowcast <- cbind(
     ord_obs,
     nowcast
   )
-  data.table::setorderv(nowcast, c("group", "reference_date"))
+  data.table::setorderv(nowcast, c(".group", "reference_date"))
   nowcast[, variable := NULL]
   return(nowcast[])
 }
@@ -111,21 +111,21 @@ enw_nowcast_samples <- function(fit, obs) {
     value.name = "sample", variable.name = "variable",
     id.vars = c(".chain", ".iteration", ".draw")
   )
-  max_delay <- nrow(nowcast) / (max(obs$group) * max(nowcast$.draw))
+  max_delay <- nrow(nowcast) / (max(obs$.group) * max(nowcast$.draw))
 
   ord_obs <- data.table::copy(obs)
   ord_obs <- ord_obs[reference_date > (max(reference_date) - max_delay)]
-  data.table::setorderv(ord_obs, c("group", "reference_date"))
+  data.table::setorderv(ord_obs, c(".group", "reference_date"))
   ord_obs <- data.table::data.table(
     .draws = 1:max(nowcast$.draw), obs = rep(list(ord_obs), max(nowcast$.draw))
   )
   ord_obs <- ord_obs[, rbindlist(obs), by = .draws]
-  ord_obs <- ord_obs[order(group, reference_date)]
+  ord_obs <- ord_obs[order(.group, reference_date)]
   nowcast <- cbind(
     ord_obs,
     nowcast
   )
-  data.table::setorderv(nowcast, c("group", "reference_date"))
+  data.table::setorderv(nowcast, c(".group", "reference_date"))
   nowcast[, variable := NULL][, .draws := NULL]
   return(nowcast[])
 }
@@ -148,7 +148,7 @@ enw_summarise_samples <- function(samples, probs = c(
                                     0.05, 0.2, 0.35, 0.5,
                                     0.65, 0.8, 0.95
                                   ),
-                                  by = c("reference_date", "group")) {
+                                  by = c("reference_date", ".group")) {
   obs <- samples[.draw == 1]
   obs[, c(".draw", ".iteration", "sample", ".chain") := NULL]
 
@@ -186,14 +186,14 @@ enw_summarise_samples <- function(samples, probs = c(
 #' @importFrom data.table as.data.table setcolorder
 enw_add_latest_obs_to_nowcast <- function(nowcast, obs) {
   obs <- data.table::as.data.table(obs)
-  obs <- obs[, .(reference_date, group, latest_confirm = confirm)]
+  obs <- obs[, .(reference_date, .group, latest_confirm = confirm)]
   out <- merge(
     nowcast, obs,
-    by = c("reference_date", "group"), all.x = TRUE
+    by = c("reference_date", ".group"), all.x = TRUE
   )
   data.table::setcolorder(
     out,
-    neworder = c("reference_date", "group", "latest_confirm", "confirm")
+    neworder = c("reference_date", ".group", "latest_confirm", "confirm")
   )
   return(out[])
 }
@@ -219,12 +219,12 @@ enw_pp_summary <- function(fit, diff_obs,
   )
 
   ord_obs <- data.table::copy(diff_obs)
-  data.table::setorderv(ord_obs, c("reference_date", "group"))
+  data.table::setorderv(ord_obs, c("reference_date", ".group"))
   pp <- cbind(
     ord_obs,
     pp
   )
-  data.table::setorderv(pp, c("group", "reference_date"))
+  data.table::setorderv(pp, c(".group", "reference_date"))
   pp[, variable := NULL]
   return(pp[])
 }

--- a/R/preprocess.R
+++ b/R/preprocess.R
@@ -17,7 +17,7 @@ enw_metadata <- function(obs, target_date = "reference_date") {
   ]
   metaobs <- unique(metaobs)
   setnames(metaobs, target_date, "date")
-  metaobs <- metaobs[, .SD[1, ], by = c("date", "group")]
+  metaobs <- metaobs[, .SD[1, ], by = c("date", ".group")]
   return(metaobs[])
 }
 
@@ -67,8 +67,8 @@ enw_add_metaobs_features <- function(metaobs, holidays = c(),
 #' @importFrom purrr map
 enw_extend_date <- function(metaobs, max_delay = 20) {
   exts <- data.table::copy(metaobs)
-  exts <- exts[, .SD[date == max(date)], by = group]
-  exts <- split(exts, by = "group")
+  exts <- exts[, .SD[date == max(date)], by = .group]
+  exts <- split(exts, by = ".group")
   exts <- purrr::map(
     exts,
     ~ data.table::data.table(
@@ -84,7 +84,7 @@ enw_extend_date <- function(metaobs, max_delay = 20) {
     data.table::copy(metaobs)[, observed := TRUE],
     exts[, observed := FALSE]
   )
-  data.table::setorderv(exts, c("group", "date"))
+  data.table::setorderv(exts, c(".group", "date"))
   return(exts[])
 }
 
@@ -99,11 +99,11 @@ enw_extend_date <- function(metaobs, max_delay = 20) {
 enw_assign_group <- function(obs, by = c()) {
   obs <- data.table::as.data.table(obs)
   if (length(by) == 0) {
-    obs <- obs[, group := 1]
+    obs <- obs[, .group := 1]
   } else {
     groups_index <- data.table::copy(obs)
     groups_index <- unique(groups_index[, ..by])
-    groups_index[, group := 1:.N]
+    groups_index[, .group := 1:.N]
     obs <- merge(obs, groups_index, by = by, all.x = TRUE)
   }
   return(obs = obs[])
@@ -138,9 +138,9 @@ enw_add_max_reported <- function(obs) {
   orig_latest <- enw_latest_data(obs)
   orig_latest <- orig_latest[
     ,
-    .(reference_date, group, max_confirm = confirm)
+    .(reference_date, .group, max_confirm = confirm)
   ]
-  obs <- obs[orig_latest, on = c("reference_date", "group")]
+  obs <- obs[orig_latest, on = c("reference_date", ".group")]
   obs[, cum_prop_reported := confirm / max_confirm]
   return(obs[])
 }
@@ -227,7 +227,7 @@ enw_latest_data <- function(obs, ref_window) {
 #' @param obs A data frame containing at least the following variables:
 #' `reference date` (index date of interest), `report_date` (report date for
 #' observations), `confirm` (cumulative observations by reference and report
-#' date), and `group` (as added by [enw_assign_group()]).
+#' date), and `.group` (as added by [enw_assign_group()]).
 #'
 #' @param set_negatives_to_zero Logical, defaults to TRUE. Should negative
 #' counts (for calculated incidence of observations) be set to zero. Currently
@@ -255,12 +255,12 @@ enw_new_reports <- function(obs, set_negatives_to_zero = TRUE) {
   reports <- data.table::copy(obs)
   reports <- reports[order(reference_date)]
   reports[, new_confirm := confirm - data.table::shift(confirm, fill = 0),
-    by = c("reference_date", "group")
+    by = c("reference_date", ".group")
   ]
   reports <- reports[, .SD[reference_date >= min(report_date)],
-    by = c("group")
+    by = c(".group")
   ]
-  reports <- reports[, delay := 0:(.N - 1), by = c("reference_date", "group")]
+  reports <- reports[, delay := 0:(.N - 1), by = c("reference_date", ".group")]
 
   if (!is.null(reports$max_confirm)) {
     reports[, prop_reported := new_confirm / max_confirm]
@@ -288,7 +288,7 @@ enw_new_reports <- function(obs, set_negatives_to_zero = TRUE) {
 enw_filter_obs <- function(obs, max_delay) {
   obs <- data.table::copy(obs)
   obs <- obs[, .SD[report_date <= (reference_date + max_delay - 1)],
-    by = c("reference_date", "group")
+    by = c("reference_date", ".group")
   ]
   return(obs[])
 }
@@ -299,7 +299,7 @@ enw_filter_obs <- function(obs, max_delay) {
 #' and columns being observations by report date
 #'
 #' @param obs A data frame as produced by [enw_new_reports()]. Must contain the
-#' following variables: `reference_date`, `group`, `delay`.
+#' following variables: `reference_date`, `.group`, `delay`.
 #'
 #' @return A data frame with each row being a reference date, and columns being
 #' observations by reporting delay.
@@ -318,10 +318,10 @@ enw_reporting_triangle <- function(obs) {
     )
   }
   reports <- data.table::dcast(
-    obs, group + reference_date ~ delay,
+    obs, .group + reference_date ~ delay,
     value.var = "new_confirm", fill = 0
   )
-  data.table::setorderv(reports, c("reference_date", "group"))
+  data.table::setorderv(reports, c("reference_date", ".group"))
   return(reports[])
 }
 
@@ -341,10 +341,10 @@ enw_reporting_triangle <- function(obs) {
 enw_reporting_triangle_to_long <- function(obs) {
   reports_long <- data.table::melt(
     obs,
-    id.vars = c("reference_date", "group"),
+    id.vars = c("reference_date", ".group"),
     variable.name = "delay", value.name = "new_confirm"
   )
-  data.table::setorderv(reports_long, c("reference_date", "group"))
+  data.table::setorderv(reports_long, c("reference_date", ".group"))
   return(reports_long[])
 }
 
@@ -445,10 +445,10 @@ enw_construct_data <- function(obs, new_confirm, latest, reporting_triangle,
     metareference = list(metareference),
     metareport = list(metareport),
     metadelay = list(metadelay),
-    time = nrow(latest[group == 1]),
-    snapshots = nrow(unique(obs[, .(group, report_date)])),
+    time = nrow(latest[.group == 1]),
+    snapshots = nrow(unique(obs[, .(.group, report_date)])),
     by = list(by),
-    groups = length(unique(obs$group)),
+    groups = length(unique(obs$.group)),
     max_delay = max_delay,
     max_date = max(obs$report_date)
   )
@@ -559,7 +559,7 @@ enw_preprocess_data <- function(obs, by = c(), max_delay = 20,
     obs[
       report_date == (reference_date + max_delay - 1),
       confirm := max_confirm,
-      by = "group"
+      by = ".group"
     ]
   }
 
@@ -571,22 +571,22 @@ enw_preprocess_data <- function(obs, by = c(), max_delay = 20,
   )
 
   # filter obs based on diff constraints
-  obs <- merge(obs, diff_obs[, .(reference_date, report_date, group)],
-    by = c("reference_date", "report_date", "group")
+  obs <- merge(obs, diff_obs[, .(reference_date, report_date, .group)],
+    by = c("reference_date", "report_date", ".group")
   )
 
   # update grouping in case any are now missing
-  setnames(obs, "group", "old_group")
+  setnames(obs, ".group", ".old_group")
   obs <- enw_assign_group(obs, by)
 
   # update diff data groups using updated groups
   diff_obs <- merge(
     diff_obs,
-    obs[, .(reference_date, report_date, new_group = group, group = old_group)],
-    by = c("reference_date", "report_date", "group")
+    obs[, .(reference_date, report_date, .new_group = .group, .group = .old_group)],
+    by = c("reference_date", "report_date", ".group")
   )
-  diff_obs[, group := new_group][, new_group := NULL]
-  obs[, old_group := NULL]
+  diff_obs[, .group := .new_group][, .new_group := NULL]
+  obs[, .old_group := NULL]
 
   reporting_triangle <- enw_reporting_triangle(diff_obs)
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -140,10 +140,10 @@ utils::globalVariables(
     ".", ".draw", "max_treedepth", "no_at_max_treedepth",
     "per_at_max_treedepth", "q20", "q5", "q80", "q95", "quantile",
     "sd", "..by", "cmf", "day_of_week", "delay", "new_confirm",
-    "observed", "old_group", "reference_date", "report_date",
+    "observed", ".old_group", "reference_date", "report_date",
     "reported_cases", "s", "time", "extend_date", "effects",
-    "confirm", "effects", "fixed", "group", "logmean", "logsd",
-    "new_group", "observed", "latest_confirm", "mad", "variable",
+    "confirm", "effects", "fixed", ".group", "logmean", "logsd",
+    ".new_group", "observed", "latest_confirm", "mad", "variable",
     "fit", "patterns", ".draws", "prop_reported", "max_confirm",
     "run_time", "cum_prop_reported"
   )

--- a/man/enw_filter_obs.Rd
+++ b/man/enw_filter_obs.Rd
@@ -10,7 +10,7 @@ enw_filter_obs(obs, max_delay)
 \item{obs}{A data frame containing at least the following variables:
 \verb{reference date} (index date of interest), \code{report_date} (report date for
 observations), \code{confirm} (cumulative observations by reference and report
-date), and \code{group} (as added by \code{\link[=enw_assign_group]{enw_assign_group()}}).}
+date), and \code{.group} (as added by \code{\link[=enw_assign_group]{enw_assign_group()}}).}
 
 \item{max_delay}{Numeric defaults to 20. The maximum number of days to
 include in the delay distribution. Computation scales non-linearly with this

--- a/man/enw_new_reports.Rd
+++ b/man/enw_new_reports.Rd
@@ -10,7 +10,7 @@ enw_new_reports(obs, set_negatives_to_zero = TRUE)
 \item{obs}{A data frame containing at least the following variables:
 \verb{reference date} (index date of interest), \code{report_date} (report date for
 observations), \code{confirm} (cumulative observations by reference and report
-date), and \code{group} (as added by \code{\link[=enw_assign_group]{enw_assign_group()}}).}
+date), and \code{.group} (as added by \code{\link[=enw_assign_group]{enw_assign_group()}}).}
 
 \item{set_negatives_to_zero}{Logical, defaults to TRUE. Should negative
 counts (for calculated incidence of observations) be set to zero. Currently

--- a/man/enw_reporting_triangle.Rd
+++ b/man/enw_reporting_triangle.Rd
@@ -8,7 +8,7 @@ enw_reporting_triangle(obs)
 }
 \arguments{
 \item{obs}{A data frame as produced by \code{\link[=enw_new_reports]{enw_new_reports()}}. Must contain the
-following variables: \code{reference_date}, \code{group}, \code{delay}.}
+following variables: \code{reference_date}, \code{.group}, \code{delay}.}
 }
 \value{
 A data frame with each row being a reference date, and columns being

--- a/man/enw_summarise_samples.Rd
+++ b/man/enw_summarise_samples.Rd
@@ -7,7 +7,7 @@
 enw_summarise_samples(
   samples,
   probs = c(0.05, 0.2, 0.35, 0.5, 0.65, 0.8, 0.95),
-  by = c("reference_date", "group")
+  by = c("reference_date", ".group")
 )
 }
 \arguments{


### PR DESCRIPTION
This PR should fix #99 on the develop branch. All group, old_group and new_group variables have been prefixed with a dot.