### PR TITLE
Change prior transformation from inv_sqrt to inv_square

### DIFF
--- a/inst/stan/epinowcast.stan
+++ b/inst/stan/epinowcast.stan
@@ -128,7 +128,7 @@ transformed parameters{
   }
   }
   // transform phi to overdispersion scale
-  phi = inv_sqrt(sqrt_phi);
+  phi = inv_square(sqrt_phi);
   // debug issues in truncated data if/when they appear
   if (debug) {
 #include /chunks/debug.stan


### PR DESCRIPTION
This PR changes the implementation of the prior on `phi` to what is probably intended: if we put a half-normal prior on `1/sqrt(phi)`, we have to transform the parameter using `inv_square`, not `inv_sqrt`, to obtain `phi`. I think this means that the current implementation had a larger prior on `phi` than intended, meaning less overdispersion than intended.