### PR TITLE
Fix compilation issue from cmdstan 2.30.0

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -107,7 +107,7 @@ jobs:
         run: |
           print(list.files("C:/rtools42"))
           cmdstanr::check_cmdstan_toolchain(fix = TRUE)
-          cmdstanr::install_cmdstan(cores = 2, version = "2.29.0")
+          cmdstanr::install_cmdstan(cores = 2)
         shell: Rscript {0}
 
       - name: Session info

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -53,7 +53,7 @@ jobs:
         run: |
           print(list.files("C:/rtools42"))
           cmdstanr::check_cmdstan_toolchain(fix = TRUE)
-          cmdstanr::install_cmdstan(cores = 2, version = "2.29.0")
+          cmdstanr::install_cmdstan(cores = 2)
         shell: Rscript {0}
 
       - name: Install package

--- a/R/model.R
+++ b/R/model.R
@@ -287,10 +287,6 @@ enw_inits <- function(data) {
 #' @param profile Logical, defaults to `FALSE`. Should the model be profiled?
 #' For more on profiling see the [`cmdstanr` documentation](https://mc-stan.org/cmdstanr/articles/profiling.html). # nolint
 #'
-#' @param stanc_options A list of options to pass to the `stanc_options` of
-#' [cmdstanr::cmdstan_model()]. By default "01" is passed which specifies simple
-#' optimisations should be done by the prior to compilation.
-#'
 #' @param ... Additional arguments passed to [cmdstanr::cmdstan_model()].
 #'
 #' @return A `cmdstanr` model.
@@ -302,7 +298,7 @@ enw_inits <- function(data) {
 #' mod <- enw_model()
 enw_model <- function(model, include, compile = TRUE,
                       threads = FALSE, profile = FALSE,
-                      stanc_options = list("O1"), verbose = TRUE, ...) {
+                      stanc_options = list(), verbose = TRUE, ...) {
   if (missing(model)) {
     model <- "stan/epinowcast.stan"
     model <- system.file(model, package = "epinowcast")

--- a/inst/stan/chunks/debug.stan
+++ b/inst/stan/chunks/debug.stan
@@ -1,8 +1,8 @@
     for (i in 1:npmfs) {
       int j = 0;
       for (k in 1:dmax) {
-        j += is_nan(fabs(pmfs[k, i])) ? 1 : 0;
-        j += is_inf(fabs(pmfs[k, i])) ? 1 : 0;
+        j += is_nan(abs(pmfs[k, i])) ? 1 : 0;
+        j += is_inf(abs(pmfs[k, i])) ? 1 : 0;
       }
       j += phi <= 1e-3 ? 1 : 0;
       if (j) {
@@ -28,8 +28,8 @@
     }
     int j = 0;
     for (k in 1:urds) {
-      j += is_nan(fabs(srdlh[k])) ? 1 : 0;
-      j += is_inf(fabs(srdlh[k])) ? 1 : 0;
+      j += is_nan(abs(srdlh[k])) ? 1 : 0;
+      j += is_inf(abs(srdlh[k])) ? 1 : 0;
     }
     if (j) {
       print("Hazard effects on report date");

--- a/tests/testthat/test-enw_model.R
+++ b/tests/testthat/test-enw_model.R
@@ -1,14 +1,19 @@
 test_that("enw_model can compile the default model", {
   skip_on_cran()
-  enw_model()
+  expect_error(enw_model(), NA)
 })
 
 test_that("enw_model can compile the multi-threaded model", {
   skip_on_cran()
-  enw_model(threads = TRUE)
+  expect_error(enw_model(threads = TRUE), NA)
 })
 
 test_that("enw_model can compile using profiling", {
   skip_on_cran()
-  enw_model(profile = TRUE)
+  expect_error(enw_model(profile = TRUE), NA)
+})
+
+test_that("enw_model can compile the default model", {
+  skip_on_cran()
+  expect_error(enw_model(compile = FALSE), NA)
 })


### PR DESCRIPTION
This PR fixes the compilation issue flagged in #105 using the suggestion from @sbfnk to drop optimisation flags. Tested locally everything now works as expected. In addition to the above change stan code has been updated to remove warnings from cmdstan `2.30.0` and CI has been reset to use the latest `cmdstan` version. 