### PR TITLE
Add loglogistic parametric distribution

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# epinowcast 0.2.0
+
+## Model
+- Added support for parametric log-logistic delay distributions. See [#128](https://github.com/epiforecasts/epinowcast/pull/128) by [@adrian-lison](https://github.com/adrian-lison).
+
 # epinowcast 0.1.0
 
 This is a major release focusing on improving the user experience, and preparing for future package extensions, with an increase in modularity, development of a flexible and full-featured formula interface, and hopefully future-proofing as far as possible. This prepares the ground for future model extensions which will allow a broad range of real-time infectious disease questions to be better answered. These extensions include:

--- a/R/model-modules.R
+++ b/R/model-modules.R
@@ -10,7 +10,7 @@
 #'
 #' @param distribution A character vector describing the parametric delay
 #' distribution to use. Current options are: "none", "lognormal", "gamma",
-#' and "exponential" with the default being "lognormal".
+#' "exponential", and "loglogistic", with the default being "lognormal".
 #'
 #' @param non_parametric A formula (as implemented in [enw_formula()])
 #' describing the non-parametric logit hazard model. This can use features
@@ -40,7 +40,7 @@ enw_reference <- function(parametric = ~1, distribution = "lognormal",
     stop("The non-parametric reference model has not yet been implemented")
   }
   distribution <- match.arg(
-    distribution, c("none", "exponential", "lognormal", "gamma")
+    distribution, c("none", "exponential", "lognormal", "gamma", "loglogistic")
   )
   if (distribution %in% "none") {
     warning(
@@ -52,7 +52,8 @@ enw_reference <- function(parametric = ~1, distribution = "lognormal",
     distribution %in% "none", 0,
     distribution %in% "exponential", 1,
     distribution %in% "lognormal", 2,
-    distribution %in% "gamma", 3
+    distribution %in% "gamma", 3,
+    distribution %in% "loglogistic", 4
   )
 
   pform <- enw_formula(parametric, data$metareference[[1]], sparse = TRUE)

--- a/inst/stan/epinowcast.stan
+++ b/inst/stan/epinowcast.stan
@@ -31,7 +31,7 @@ data {
   matrix[refp_fnrow, refp_fncol + 1] refp_fdesign; // design matrix for pmfs
   int refp_rncol; // number of standard deviations to use for pooling
   matrix[refp_fncol, refp_rncol + 1] refp_rdesign; // Pooling pmf design matrix 
-  int model_refp; // parametric distribution (0 = none, 1 = exp. 2 = lognormal, 2 = gamma)
+  int model_refp; // parametric distribution (0 = none, 1 = exp, 2 = lognormal, 3 = gamma, 4 = loglogistic)
   // Reporting day model
   int model_rep; // Reporting day model in use
   int rep_t; // how many reporting days are there (t + dmax - 1)

--- a/inst/stan/functions/discretised_reporting_prob.stan
+++ b/inst/stan/functions/discretised_reporting_prob.stan
@@ -19,9 +19,8 @@ vector discretised_reporting_prob(real mu, real sigma, int n, int dist, int max_
     }
   } else if (dist == 4) {
     real emu = exp(mu);
-    real esigma = exp(sigma);
     for (i in 1:n) {
-      upper_cdf[i] = loglogistic_cdf(i | emu, esigma);
+      upper_cdf[i] = loglogistic_cdf(i | emu, sigma);
     }
   } else {
     reject("Unknown distribution function provided.");

--- a/inst/stan/functions/discretised_reporting_prob.stan
+++ b/inst/stan/functions/discretised_reporting_prob.stan
@@ -17,6 +17,12 @@ vector discretised_reporting_prob(real mu, real sigma, int n, int dist, int max_
     for (i in 1:n) {
       upper_cdf[i] = gamma_cdf(i | emu, sigma);
     }
+  } else if (dist == 4) {
+    real emu = exp(mu);
+    real esigma = exp(sigma);
+    for (i in 1:n) {
+      upper_cdf[i] = loglogistic_cdf(i | emu, esigma);
+    }
   } else {
     reject("Unknown distribution function provided.");
   }

--- a/man/enw_reference.Rd
+++ b/man/enw_reference.Rd
@@ -22,7 +22,7 @@ model (note not recommended until the \code{non_parametric} model is implemented
 
 \item{distribution}{A character vector describing the parametric delay
 distribution to use. Current options are: "none", "lognormal", "gamma",
-and "exponential" with the default being "lognormal".}
+"exponential", and "loglogistic", with the default being "lognormal".}
 
 \item{non_parametric}{A formula (as implemented in \code{\link[=enw_formula]{enw_formula()}})
 describing the non-parametric logit hazard model. This can use features

--- a/tests/testthat/test-enw_reference.R
+++ b/tests/testthat/test-enw_reference.R
@@ -24,11 +24,17 @@ test_that("enw_reference supports parametric models", {
     )
   )
 
-  expect_equal(
-    enw_reference(distribution = "gamma", data = pobs)$data$model_refp, 3
-  )
+  default_ref <- enw_reference(data = pobs)
+  expect_equal(default_ref$data$model_refp, 2) # default is lognormal
   exp_ref <- enw_reference(distribution = "exponential", data = pobs)
   expect_equal(exp_ref$data$model_refp, 1)
+  lognormal_ref <- enw_reference(distribution = "lognormal", data = pobs)
+  expect_equal(lognormal_ref$data$model_refp, 2)
+  gamma_ref <- enw_reference(distribution = "gamma", data = pobs)
+  expect_equal(gamma_ref$data$model_refp, 3)
+  loglogistic_ref <- enw_reference(distribution = "loglogistic", data = pobs)
+  expect_equal(loglogistic_ref$data$model_refp, 4)
+  
   expect_equal(
     exp_ref$init(exp_ref$data, exp_ref$priors)()$refp_sd_int, numeric(0)
   )


### PR DESCRIPTION
This PR adds the loglogistic distribution as a fourth option for the parametric delay distribution. It is similar to the lognormal (slightly heavier tails), and often used in survival modeling due to its closed-form solution for the hazard function. I have managed to work out the closed-form solution for the discrete hazard case, so this will be another parametric function (aside from the exponential) that we can efficiently implement on the hazard scale (i.e. using vectorized, simple computations only). Can work on this after this PR is merged.