### PR TITLE
Bug: ref_as_p not activating

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,9 +9,12 @@
 - Implemented direct specification of parametric baseline hazards. See #134 by @adrian-lison.
 - Refactored the observation model, the combination of logit hazards, and the effects priors to be contained in generic functions to make extending package functionality easier. See #137 by @seabbs.
 
-
 ## Documentation
 - Removed explicit links to authors and issues in the `NEWS.md` file. See #132 by @choi-hannah.
+
+## Bugs
+
+- The probability-only model (i.e only a parametric distribution is used and hence the hazard scale is not needed) was not used due to a mistake specifying `ref_as_p` in the stan code. There was an additional issue in that the `enw_report()` module currently self-declares as on regardless of it is or not. This bug had no impact on results but would have increased runtimes for simple models. Both of these issues were fixed in #142 by @seabbs.
 
 # epinowcast 0.1.0
 

--- a/R/model-modules.R
+++ b/R/model-modules.R
@@ -180,7 +180,9 @@ enw_report <- function(non_parametric = ~0, structural = ~0, data) {
     )
   )
   data_list$rep_t <- data$time[[1]] + data$max_delay[[1]] - 1
-  data_list$model_rep <- as.numeric(!as_string_formula(formula) %in% "1")
+  data_list$model_rep <- as.numeric(
+    !as_string_formula(non_parametric) %in% "~1"
+  )
 
   out <- list()
   out$formula$non_parametric <- form$formula

--- a/inst/stan/epinowcast.stan
+++ b/inst/stan/epinowcast.stan
@@ -67,7 +67,7 @@ transformed data{
   vector[g] eobs_init = log(to_vector(latest_obs[1, 1:g]) + 1);
   // if no reporting day effects use native probability for reference day
   // effects, i.e. do not convert to logit hazard
-  int ref_as_p = (model_rep > 0 || model_refp > 0) ? 0 : 1; 
+  int ref_as_p = (model_rep > 0 || model_refp == 0) ? 0 : 1; 
 }
 
 parameters {

--- a/tests/testthat/test-enw_reference.R
+++ b/tests/testthat/test-enw_reference.R
@@ -34,7 +34,8 @@ test_that("enw_reference supports parametric models", {
   expect_equal(gamma_ref$data$model_refp, 3)
   loglogistic_ref <- enw_reference(distribution = "loglogistic", data = pobs)
   expect_equal(loglogistic_ref$data$model_refp, 4)
-  
+  no_ref <- enw_reference(distribution = "none", data = pobs)
+  expect_equal(no_ref$data$model_refp, 0)
   expect_equal(
     exp_ref$init(exp_ref$data, exp_ref$priors)()$refp_sd_int, numeric(0)
   )

--- a/tests/testthat/test-enw_report.R
+++ b/tests/testthat/test-enw_report.R
@@ -15,6 +15,7 @@ test_that("enw_report supports non-parametric models", {
   expect_equal(
     enw_report(~0, data = pobs)$formula$non_parametric, "~1"
   )
+  expect_equal(enw_report(~0, data = pobs)$data$model_rep, 1)
 })
 
 test_that("enw_report does not support structural models", {

--- a/tests/testthat/test-enw_report.R
+++ b/tests/testthat/test-enw_report.R
@@ -15,7 +15,7 @@ test_that("enw_report supports non-parametric models", {
   expect_equal(
     enw_report(~0, data = pobs)$formula$non_parametric, "~1"
   )
-  expect_equal(enw_report(~0, data = pobs)$data$model_rep, 1)
+  expect_equal(enw_report(~0, data = pobs)$data$model_rep, 0)
 })
 
 test_that("enw_report does not support structural models", {


### PR DESCRIPTION
This PR fixes #141 by correctly setting `ref_as_p` based on `model_rep` and `model_refp` as passed by `enw_report()` and `enw_reference()`. It also adds additional tests to cover this issue in the future. 

It replicates the fix added in #140 and replaces it.