### PR TITLE
Fix: Escape inline R code in features vignette to prevent parsing errors

### DIFF
--- a/vignettes/features.Rmd
+++ b/vignettes/features.Rmd
@@ -93,11 +93,11 @@ Specify the generative model for the expected latent process (e.g., infections, 
 
 | Model type | What it assumes | How to specify | Example |
 |------------|-----------------|----------------|---------|
-| Daily random effects | Flexible day-to-day changes | `r = ~0 + (1 | day:.group)` (default) | Most flexible |
-| Weekly random walk | Smooth week-to-week trends | `r = ~1 + rw(week, by = .group)` | Smoother estimates |
+| Daily random effects | Flexible day-to-day changes | ``r = ~0 + (1 | day:.group)`` (default) | Most flexible |
+| Weekly random walk | Smooth week-to-week trends | ``r = ~1 + rw(week, by = .group)`` | Smoother estimates |
 | Growth rate | Exponential growth/decline | `generation_time = 1` (default) | Simple trend |
 | Renewal process | Epidemic dynamics | `generation_time = c(0.2, 0.5, 0.3)` | [Rt estimation vignette](single-timeseries-rt-estimation.html) |
-| Fixed effects | Covariates (e.g., interventions) | `r = ~1 + intervention + ...` | Include predictors |
+| Fixed effects | Covariates (e.g., interventions) | ``r = ~1 + intervention + ...`` | Include predictors |
 | Observation modifiers | Ascertainment variation (e.g., day of week) | `observation = ~1 + day_of_week` | Adjust for reporting patterns |
 
 **Key functions:**


### PR DESCRIPTION
## Summary
Fixes build failure on main where the features vignette failed to render due to inline R code being incorrectly parsed.

## Changes
- Changed single backticks to double backticks for three formula examples that start with `r =`
- Prevents R Markdown from attempting to execute these as inline R code

## Error fixed
```
Error: processing vignette 'features.Rmd' failed with diagnostics:
Failed to parse the inline R code: `r = ~0 + (1 | day:.group)`
Reason: <text>:1:1: unexpected '='
1: =
    ^
```

## Test plan
- [x] Changes made to features.Rmd
- [ ] Verify vignette renders successfully in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Improved formatting of code snippets in the Latent Process Models table within the vignettes for clearer presentation.
  - Updated inline code styling for “Daily random effects,” “Weekly random walk,” and “Fixed effects” entries.
  - No functional or behavioral changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->