### PR TITLE
Fix: Remove 'r =' from inline code to avoid R Markdown parsing

### DIFF
--- a/vignettes/features.Rmd
+++ b/vignettes/features.Rmd
@@ -91,13 +91,13 @@ For non-parametric approaches and mixed models, see `?enw_reference` examples.
 
 Specify the generative model for the expected latent process (e.g., infections, hospitalisations).
 
-| Model type | What it assumes | How to specify | Example |
+| Model type | What it assumes | How to specify (`r` argument) | Example |
 |------------|-----------------|----------------|---------|
-| Daily random effects | Flexible day-to-day changes | ``r = ~0 + (1 | day:.group)`` (default) | Most flexible |
-| Weekly random walk | Smooth week-to-week trends | ``r = ~1 + rw(week, by = .group)`` | Smoother estimates |
+| Daily random effects | Flexible day-to-day changes | `~0 + (1 | day:.group)` (default) | Most flexible |
+| Weekly random walk | Smooth week-to-week trends | `~1 + rw(week, by = .group)` | Smoother estimates |
 | Growth rate | Exponential growth/decline | `generation_time = 1` (default) | Simple trend |
 | Renewal process | Epidemic dynamics | `generation_time = c(0.2, 0.5, 0.3)` | [Rt estimation vignette](single-timeseries-rt-estimation.html) |
-| Fixed effects | Covariates (e.g., interventions) | ``r = ~1 + intervention + ...`` | Include predictors |
+| Fixed effects | Covariates (e.g., interventions) | `~1 + intervention + ...` | Include predictors |
 | Observation modifiers | Ascertainment variation (e.g., day of week) | `observation = ~1 + day_of_week` | Adjust for reporting patterns |
 
 **Key functions:**


### PR DESCRIPTION
## Summary
Fixes the build failure where the features vignette still fails to render even after #612.

## Problem
The previous fix using double backticks didn't work because R Markdown still tries to parse anything inside `` `r `` as inline R code, even with double backticks.

## Solution
- Removed the `r =` prefix from the three problematic formulas
- Updated column header to "How to specify (`r` argument)" to clarify these are values for the `r` parameter
- Now shows just the formula: `~0 + (1 | day:.group)` instead of ``r = ~0 + (1 | day:.group)``

## Changes
- `~0 + (1 | day:.group)` instead of ``r = ~0 + (1 | day:.group)``
- `~1 + rw(week, by = .group)` instead of ``r = ~1 + rw(week, by = .group)``
- `~1 + intervention + ...` instead of ``r = ~1 + intervention + ...``

## Test plan
- [x] Changes made to features.Rmd
- [ ] Verify vignette renders successfully in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Standardized syntax presentation in feature tables, explicitly noting that model specifications are provided via the r argument.
  * Updated examples from r = ... style to direct formula notation (e.g., ~0 + (1 | day:.group), ~1 + rw(week, by = .group), ~1 + intervention + ...).
  * Improved consistency of code blocks and inline code formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->