### PR TITLE
Update R-CMD-check badge to be branch-specific

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -18,7 +18,7 @@ knitr::opts_chunk$set(
 <!-- badges: start -->
 [![Lifecycle:
 stable](https://img.shields.io/badge/lifecycle-stable-brightgreen.svg)](https://lifecycle.r-lib.org/articles/stages.html#stable)
-[![R-CMD-check](https://github.com/epinowcast/epinowcast/workflows/R-CMD-check/badge.svg)](https://github.com/epinowcast/epinowcast/actions/workflows/R-CMD-check.yaml) [![Codecov test coverage](https://codecov.io/gh/epinowcast/epinowcast/branch/main/graph/badge.svg)](https://app.codecov.io/gh/epinowcast/epinowcast)
+[![R-CMD-check](https://github.com/epinowcast/epinowcast/actions/workflows/R-CMD-check.yaml/badge.svg?branch=main)](https://github.com/epinowcast/epinowcast/actions/workflows/R-CMD-check.yaml) [![Codecov test coverage](https://codecov.io/gh/epinowcast/epinowcast/branch/main/graph/badge.svg)](https://app.codecov.io/gh/epinowcast/epinowcast)
 </br>
 [![Universe](https://epinowcast.r-universe.dev/badges/epinowcast)](https://epinowcast.r-universe.dev/epinowcast)
 [![MIT

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 [![Lifecycle:
 stable](https://img.shields.io/badge/lifecycle-stable-brightgreen.svg)](https://lifecycle.r-lib.org/articles/stages.html#stable)
-[![R-CMD-check](https://github.com/epinowcast/epinowcast/workflows/R-CMD-check/badge.svg)](https://github.com/epinowcast/epinowcast/actions/workflows/R-CMD-check.yaml)
+[![R-CMD-check](https://github.com/epinowcast/epinowcast/actions/workflows/R-CMD-check.yaml/badge.svg?branch=main)](https://github.com/epinowcast/epinowcast/actions/workflows/R-CMD-check.yaml)
 [![Codecov test
 coverage](https://codecov.io/gh/epinowcast/epinowcast/branch/main/graph/badge.svg)](https://app.codecov.io/gh/epinowcast/epinowcast)
 </br>


### PR DESCRIPTION
## Summary

Updates the R-CMD-check badge in README to show branch-specific status for the main branch by adding the `?branch=main` parameter to the badge URL.

## Changes

- Modified badge URL from workflow-based to action-based format
- Added branch parameter to ensure badge reflects main branch status
- Rendered README.md from updated README.Rmd

This provides clearer CI/CD status indication by showing the specific status of checks on the main branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the build status badge to use a branch-specific URL (main), ensuring the displayed status accurately reflects the main branch.
  * Adjusted the badge link target to the corresponding actions workflow badge.
  * No functional or API changes; this affects only how build status is shown.
  * Other badges remain unchanged.
  * Users will see the correct CI status in the project’s README and related documentation pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->