### PR TITLE
Run spelling checks only on R release version

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -33,14 +33,15 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: ubuntu-latest,   r: 'release', rtools: ''}
-          - {os: ubuntu-latest,   r: 'oldrel-1', rtools: ''}
-          - {os: ubuntu-latest,   r: '4.1', rtools: ''}
+          - {os: ubuntu-latest,   r: 'release', rtools: '', spelling: 'true'}
+          - {os: ubuntu-latest,   r: 'oldrel-1', rtools: '', spelling: 'false'}
+          - {os: ubuntu-latest,   r: '4.1', rtools: '', spelling: 'false'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       R_KEEP_PKG_SOURCE: yes
       NOT_CRAN: true
+      RUN_SPELLING_CHECK: ${{ matrix.config.spelling }}
       
     steps:
       - name: cmdstan env vars

--- a/tests/spelling.R
+++ b/tests/spelling.R
@@ -1,8 +1,14 @@
 if (requireNamespace("spelling", quietly = TRUE)) {
-  spelling::spell_check_test(
-    vignettes = TRUE,
-    error = TRUE,
-    skip_on_cran = TRUE,
-    lang = "en-GB"
-  )
+  # Only run spell check when RUN_SPELLING_CHECK is set to avoid
+  # inconsistencies between R versions
+  run_spelling <- Sys.getenv("RUN_SPELLING_CHECK", "false")
+
+  if (tolower(run_spelling) == "true") {
+    spelling::spell_check_test(
+      vignettes = TRUE,
+      error = TRUE,
+      skip_on_cran = TRUE,
+      lang = "en-GB"
+    )
+  }
 }


### PR DESCRIPTION
## Summary

Fixes spelling check failures on older R versions in CI by only running the spell check on the R release version.

## Problem

Spelling checks can differ between R versions, causing CI failures on older R versions (oldrel-1, 4.1) even when the spelling is correct on the release version. This happens because different R versions may have different dictionaries or spell check implementations.

## Solution

- Add `RUN_SPELLING_CHECK` environment variable to the CI matrix
- Set it to `'true'` only for the release R version
- Set it to `'false'` for older versions (oldrel-1, 4.1)
- Modified `tests/spelling.R` to check this variable before running spell checks

This ensures consistent spelling validation against the release version whilst avoiding version-specific failures.

## Test plan

- CI should now pass spelling checks only on the release R version
- Older R versions should skip the spelling check entirely

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration workflow to conditionally run spell checking during automated package validation. Configuration now includes environment-specific settings for selective spell validation across different R versions, improving efficiency in the automated testing pipeline by running spell checks on designated builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->