### PR TITLE
fix(report): derive report axis length from report metadata

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -51,6 +51,10 @@
   The fixed-effects design matrix was collapsing to a vector after the intercept was dropped, causing Stan to error with `mismatch in number dimensions declared and found in context`.
   See #783 by @seabbs.
 
+- Fixed `enw_report()` recycling the report-date index (`rep_findex`) when the report axis is longer than `time + max_delay - 1`, for example after `enw_complete_dates(completion_beyond_max_report = TRUE)`.
+  Previously this emitted a "data length is not a sub-multiple or multiple" warning and mis-mapped report-date effects across groups and times; the number of report dates per group is now read from the report metadata.
+  See #868.
+
 # epinowcast 0.6.0
 
 This release prepares the package for CRAN submission and introduces new methods for inspecting `epinowcast` and preprocessed data objects, including `print()`, `summary()`, `plot()` and an `enw_get_data()` accessor.

--- a/R/model-modules.R
+++ b/R/model-modules.R
@@ -363,16 +363,14 @@ enw_report <- function(non_parametric = ~0, structural = NULL, data) {
   }
 
   # map report date effects to groups and times
+  rep_t <- nrow(data$metareport[[1]]) %/% data$groups[[1]]
+  if (rep_t * data$groups[[1]] != nrow(data$metareport[[1]])) {
+    cli::cli_abort("Report metadata is not rectangular across groups.")
+  }
   data_list$rep_findex <- t(
-    matrix(
-      data_list$rep_findex,
-      ncol = data$groups[[1]],
-      nrow = data$time[[1]] +
-        data$max_delay - 1
-    )
+    matrix(data_list$rep_findex, ncol = data$groups[[1]], nrow = rep_t)
   )
-  data_list$rep_t <- data$time[[1]] +
-    data$max_delay - 1
+  data_list$rep_t <- rep_t
   data_list$model_rep <- as.numeric(
     as_string_formula(non_parametric) != "~1"
   )

--- a/tests/testthat/test-enw_report.R
+++ b/tests/testthat/test-enw_report.R
@@ -51,3 +51,22 @@ test_that("enw_report errors on report model with max_delay = 1", {
     enw_report(non_parametric = ~0, data = pobs_retro)
   )
 })
+
+test_that("enw_report uses the report axis length from the metadata", {
+  # completion_beyond_max_report extends the report axis past time + max_delay - 1
+  obs <- enw_example("observations")
+  max_delay <- 20L
+  inc <- enw_complete_dates(
+    obs,
+    max_delay = max_delay,
+    max_date = max(obs$report_date) + 14,
+    completion_beyond_max_report = TRUE
+  )
+  pobs_ext <- suppressWarnings(enw_preprocess_data(inc, max_delay = max_delay))
+
+  rep_per_group <- nrow(pobs_ext$metareport[[1]]) / pobs_ext$groups[[1]]
+  expect_gt(rep_per_group, pobs_ext$time[[1]] + max_delay - 1)
+
+  expect_no_warning(rep <- enw_report(~0, data = pobs_ext))
+  expect_equal(rep$data$rep_t, rep_per_group)
+})


### PR DESCRIPTION
### Summary

Fixes #868. `enw_report()` assumed the per-group report axis was `time + max_delay - 1` and reshaped `rep_findex` against it. When the report axis is longer (e.g. `enw_complete_dates(completion_beyond_max_report = TRUE)`), `matrix()` silently recycled `rep_findex` — emitting a "not a sub-multiple" warning and mis-mapping report-date effects.

### Changes

- `enw_report()` now takes the report dates per group from the report metadata (`nrow(metareport) %/% groups`) for both the `rep_findex` reshape and `rep_t`, and errors if the report metadata is not rectangular across groups.
- Regression test in `tests/testthat/test-enw_report.R` covering an extended report axis: asserts no recycling warning and correct `rep_t`.
- NEWS entry.

In the standard reporting triangle `nrow(metareport)/groups == time + max_delay - 1`, so existing fits are unchanged; only the previously-broken extended-axis case changes behaviour.

### Reprex (before: warns; after: clean)

```r
obs <- enw_example("observations")
inc <- enw_complete_dates(obs, max_delay = 20,
  max_date = max(obs$report_date) + 14, completion_beyond_max_report = TRUE)
pobs <- enw_preprocess_data(inc, max_delay = 20)
enw_report(~0, data = pobs)   # no longer warns; rep_t == 112
```

### Checklist

- [x] Regression test added
- [x] `NEWS.md` updated
- [x] `devtools::test()` passes locally (only failures are pre-existing `test-plot.*` snapshot tests needing the optional `vdiffr` package, unrelated to this change)
- [x] `lintr` clean on the changed code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fixed `enw_report()` incorrectly recycling the report-date index when the report axis extends beyond the standard time + max_delay - 1 calculation. Report-date effects are now correctly mapped using actual report metadata, preventing cross-group/time effect mapping errors and eliminating spurious data length warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->