### PR TITLE
ci: add merge group trigger to PR checks

### DIFF
--- a/.github/workflows/lint-changed-files.yaml
+++ b/.github/workflows/lint-changed-files.yaml
@@ -7,6 +7,7 @@ on:
       - master
       - develop
   workflow_dispatch:
+  merge_group:
 
 name: lint-changed-files
 

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -6,6 +6,7 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+  merge_group:
 
 name: pkgdown
 


### PR DESCRIPTION
Adds a `merge_group` event to the workflow, triggering status checks when a PR is added to the merge queue. Based on the [docs](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#merge_group) but may need additional work.

Fixes [#745](https://github.com/epinowcast/epinowcast/issues/745)